### PR TITLE
feat(v0.7.1): Perplexity Agent, Featherless, Moonshot, QwenCloud, pxp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,150 @@
+# v0.7.0 (2026-07-16)
+
+## Features
+- **Combos**: total redesign — 3 tabs (Overview/Combos/Templates), KPI row, search/filter, expandable cards with strategy visual indicators, drag-reorder models
+- **v0.app**: full executor rewrite — new diff protocol parser replacing v0.dev SSE, profile + credit balance display
+- **FreeBuff**: new cookie provider with NextAuth SSE executor, profile display, auto-refresh cookies
+- **OpenVecta**: new API-key provider (OpenAI-compatible, 46k+ models via modelsFetcher)
+- **Perplexity Agent**: new API-key provider — multi-model routing via Responses API (33+ models)
+- **Moonshot AI**: new API-key provider — kimi-k3 with reasoning_effort "max" support
+- **Featherless**: new API-key provider — 46,000+ HuggingFace models, live model discovery
+- **QwenCloud**: new cookie provider — multi-step auth (cookie → secToken → accessToken → SSE chat), profile display
+- **Pxpipe**: 5th token saver — multimodal prompt compression via in-process pxpipe-proxy library
+- **Semantic Cache**: Jaccard similarity-based response cache with configurable threshold + per-key identity scoping
+- **Retry**: exponential backoff + jitter + retry visualization chart in Usage page
+- **Health Timeline**: SVG sparkline in provider detail (hourly success/error bars + latency line)
+- **Cost Estimator**: real-time cost estimate in Playground stats bar
+- **Thinking Level Picker**: per-model dropdown (auto/none/minimal/low/medium/high/xhigh/max) with suffix-based forced reasoning
+- **Thought Level toggle**: per-provider global thinking override (uncommented + renamed)
+- **New Badge**: "NEW" badge for unseen providers + sidebar nav items
+- **Auto-rotate proxy**: no-auth providers can rotate across all active proxy pools (round-robin/random)
+- **Webhook Alerts**: dedicated page with Discord/Telegram/Generic channels + event toggles
+- **Web Saver UI**: Token Saver card redesign with pxpipe + semantic cache toggles
+- **Vault Key Pool**: AES-256-GCM encrypted Xiaomi MiMo key pool (69 keys) with LRU rotation
+- **Playground**: chat + compare mode with streaming
+- **Overview dashboard**: KPI cards, token saver status, free providers grid
+- **Combo Templates**: prebuilt combo library with one-click apply
+- **TLS Impersonation**: wreq-js Chrome 124 fingerprint with circuit breaker
+- **Ponytail**: dedicated regression tests for code compaction prompt system
+- **RTK git-log filter**: JS-native compactor for git log output
+- **Caveman**: upstream-aligned style rules for all 6 levels
+- **Kimi K3 free button**: referral URL on Moonshot provider page
+- **gpt-5.6-sol max thinking**: max reasoning_effort support for gpt-5.6-sol only
+- **FreeBuff/v0 profiles**: avatar, name, email, session expiry display
+- **FreeBuff/v0 auto-refresh**: capture Set-Cookie from upstream + update connection automatically
+
+## Fixes
+- **Security — Critical**: SSRF guards on proxy/relay URLs + prefetchRemoteImages; body size limits (10MB/4MB/2MB); rate limiting per API key/IP; semantic cache cross-user leak (per-key identity)
+- **Security — High**: circuit breaker half-open probe cap + slot leak on abort; auth + ACL enforced regardless of requireApiKey; HealthTimeline interval leak; alerts stale closure + debounce; combos delete stale closure
+- **Kimi/Step**: normalize reasoning_effort to backend enum (minimal→low, auto→omit)
+- **Meta AI**: AttachmentInput GraphQL schema change (omit attachments field)
+- **v0.app**: 3 critical + 4 medium audit fixes (AbortSignal, per-path text tracking, extractTextFromValue, dedupe finish, content-type check)
+- **Thinking suffix**: strip (level) from upstream model in chatCore — pass original model to translator for applyThinking
+- **MITM**: stale-lock recovery (validate PID, auto-delete orphan lock files)
+- **Webhook**: camelCase/snake_case key mismatch (alerts silently dropped)
+- **Headroom**: Kiro conversationState compression path added
+- **Gemini-CLI**: thinking budget floor (min 1024) + validated toolConfig for tools
+- **GitHub Copilot**: account identity labeling via /user fetch
+- **RTK/find**: Windows backslash path detection + drive-letter support in autodetect
+- **Codex**: capacity/rate_limit SSE patterns added to overloaded detector
+- **Antigravity**: fingerprint aligned with IDE Desktop 2.1.1
+- **Pricing**: added claude-opus-4.7/4.8, claude-sonnet-5, claude-fable-5, gpt-5.4/5.5/5.6 variants
+- **Provider audit**: api-airforce missing from validate, mimo-free/devin/vertex test probes, openvecta validate, o1/o3/o4 + claude pattern tightening, zenmux-free icon, vault cooldown cap, reasoning_effort whitelist
+
+---
+
+# v0.6.9 (2026-07-14)
+
+## Features
+- Semantic Cache: Jaccard similarity-based response cache
+- Retry: exponential backoff + jitter + retry visualization chart
+- Health Timeline: SVG sparkline in provider detail
+- Model Cost Estimator in Playground stats bar
+- RTK git-log filter + Caveman upstream-aligned style rules
+- Ponytail: dedicated regression tests
+
+## Fixes
+- Step/Kimi reasoning_effort normalization
+- buildOutput missing from RTK registry
+- PassthroughModelsSection dead import removed
+- Meta AI AttachmentInput GraphQL schema change
+
+---
+
+# v0.6.7 (2026-07-10)
+
+## Features
+- New badge system for unseen providers + sidebar nav
+- Per-model Thinking Level Picker with suffix-based forced reasoning
+- ZenMux: live model fetcher + plan auto-detect from ctoken
+- x.ai registry: grok-4.5, multi-agent, imagine models + thinkingConfig
+
+## Fixes
+- Thinking suffix leak: strip (level) from upstream model
+- Webhook alerts: camelCase/snake_case bug (all real alerts silently dropped)
+
+---
+
+# v0.6.6 (2026-07-08)
+
+## Features
+- Overview dashboard page with KPI cards
+- Token saved tracking pipeline (chatCore → usageRepo → _meta counter)
+- Providers page total redesign (modular components)
+- Usage page total redesign (Overview/Logs/Details tabs)
+- 26 SVG provider icons
+
+## Fixes
+- Cline/ClinePass 401 auth flow
+- TDZ errors (totalLatency + savedTokens)
+- HuggingChat conversationId + DeepSeek PoW solver
+- Select double-chevron fix
+
+---
+
+# v0.6.4 (2026-07-06)
+
+## Features
+- Kiro Claude Sonnet 5 support
+- Providers page UX improvements
+- OAuth providers (Windsurf, Trae, Cody)
+- Usage page total redesign
+
+---
+
+# v0.6.2 (2026-07-05)
+
+## Features
+- Hierarchical Swarm combo strategy
+- Reliability layer: Circuit Breaker, Health Monitor, Per-Key Model ACL
+- 20 cookie providers (ported from OmniRoute)
+- Devin CLI OAuth provider
+- TLS impersonation via wreq-js (Chrome 124 fingerprint)
+- ZenMux Free cookie provider
+- api.airforce cookie provider (session→API-key exchange)
+- Combo Template Library
+
+## Fixes
+- Cline 401 + ClinePass 401 auth detection
+- Cookie providers authType mismatch
+
+---
+
+# v0.6.0 (2026-07-04)
+
+## Features
+- ExtremeRouter initial fork from 9router
+- Devin CLI OAuth provider
+- Per-provider thinking config (on/off/level)
+- Hierarchical Swarm combo routing
+- Circuit Breaker + Health Monitor + Per-Key ACL
+
+## Fixes
+- Cline/ClinePass authentication flow
+- TDZ errors in streaming/non-streaming handlers
+
+---
+
 # v0.5.18 (2026-07-03)
 
 ## Features

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsalmn/extremerouter",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "ExtremeRouter CLI - AI Gateway control plane",
   "bin": {
     "extremerouter": "./cli.js"

--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -59,7 +59,7 @@ export function getPlatformEnum() {
 }
 
 export function getPlatformUserAgent() {
-  return `antigravity/1.104.0 ${platform()}/${arch()}`;
+  return `antigravity/2.1.1 ${platform()}/${arch()}`;
 }
 
 export const CLIENT_METADATA = {
@@ -129,7 +129,7 @@ export const AG_DEFAULT_TOOLS = new Set([
 
 // Antigravity chat/stream headers
 export const ANTIGRAVITY_HEADERS = {
-  "User-Agent": `antigravity/1.107.0 ${platform()}/${arch()}`
+  "User-Agent": `antigravity/2.1.1 ${platform()}/${arch()}`
 };
 
 // Cloud Code Assist API

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -212,6 +212,15 @@ export function stripThinkingSuffix(model) {
  */
 export function resolveKiroModel(model) {
   let upstream = model;
+  // FIX: Strip thinking-level suffix like "(high)" that was added by the
+  // per-model thinking picker. parseSuffix in thinkingUnified strips this for
+  // applyThinking, but resolveKiroModel also needs to strip it for the upstream
+  // modelId, otherwise "(high)" leaks into the Kiro CodeWhisperer modelId and
+  // gets rejected.
+  const parenIdx = upstream.lastIndexOf("(");
+  if (parenIdx > 0 && upstream.endsWith(")")) {
+    upstream = upstream.slice(0, parenIdx).trim();
+  }
   let agentic = false;
   let thinking = false;
   if (isAgenticModel(upstream)) {

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -13,7 +13,7 @@ import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 
 // SSE error patterns inside 200-OK body that should trigger retry as if 503
-const CODEX_SSE_OVERLOADED_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
+const CODEX_SSE_OVERLOADED_PATTERNS = ["server_is_overloaded", "service_unavailable_error", "capacity", "rate_limit_exceeded", "insufficient_quota"];
 const CODEX_SSE_PEEK_BYTES = 4096;
 
 // Server-generated item id prefixes that Codex /responses cannot resolve when store=false

--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -17,6 +17,26 @@ export class GithubExecutor extends BaseExecutor {
     this.knownCodexModels = new Set();
   }
 
+  // Fetch GitHub account identity for labeling connections by account.
+  // Returns { login, email } or null.
+  async fetchAccountIdentities(accessToken) {
+    if (!accessToken) return null;
+    try {
+      const res = await fetch("https://api.github.com/user", {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/vnd.github+json",
+          "User-Agent": "ExtremeRouter",
+        },
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return { login: data?.login || "", email: data?.email || "" };
+    } catch {
+      return null;
+    }
+  }
+
   buildUrl(model, stream, urlIndex = 0) {
     return this.config.baseUrl;
   }

--- a/open-sse/executors/index.js
+++ b/open-sse/executors/index.js
@@ -30,6 +30,8 @@ import { BlackboxWebExecutor } from "./blackbox-web.js";
 import { ZenmuxFreeExecutor } from "./zenmux-free.js";
 import { ApiAirforceExecutor } from "./api-airforce.js";
 import { FreeBuffWebExecutor } from "./freebuff-web.js";
+import { PerplexityAgentExecutor } from "./perplexity-agent.js";
+import { QwenCloudExecutor } from "./qwencloud.js";
 import { T3ChatWebExecutor } from "./t3-web.js";
 import { DuckDuckGoWebExecutor } from "./duckduckgo-web.js";
 import { VeniceWebExecutor } from "./venice-web.js";
@@ -101,6 +103,8 @@ const executors = {
   "zenmux-free": new ZenmuxFreeExecutor(),
   "api-airforce": new ApiAirforceExecutor(),
   "freebuff-web": new FreeBuffWebExecutor(),
+  "perplexity-agent": new PerplexityAgentExecutor(),
+  "qwencloud": new QwenCloudExecutor(),
   lmarena: new LMArenaExecutor(),
   puter: new PuterExecutor(),
   pollinations: new PollinationsExecutor(),
@@ -167,6 +171,8 @@ export { HuggingChatExecutor } from "./huggingchat.js";
 export { ZenmuxFreeExecutor } from "./zenmux-free.js";
 export { ApiAirforceExecutor } from "./api-airforce.js";
 export { FreeBuffWebExecutor } from "./freebuff-web.js";
+export { PerplexityAgentExecutor } from "./perplexity-agent.js";
+export { QwenCloudExecutor } from "./qwencloud.js";
 export { LMArenaExecutor } from "./lmarena.js";
 export { PuterExecutor } from "./puter.js";
 export { PollinationsExecutor } from "./pollinations.js";

--- a/open-sse/executors/perplexity-agent.js
+++ b/open-sse/executors/perplexity-agent.js
@@ -1,0 +1,214 @@
+import { BaseExecutor } from "./base.js";
+import { SSE_DONE, SSE_HEADERS_NO_BUFFER } from "../utils/sseConstants.js";
+import { sseChunk } from "../utils/sse.js";
+import { proxyAwareFetch } from "../utils/proxyFetch.js";
+
+// PerplexityAgentExecutor — multi-model routing via Perplexity's Agent API.
+//
+// Translates OpenAI chat.completions requests to/from Perplexity's Responses API:
+//   - Converts messages[] → input (string or array format)
+//   - Translates streaming: response.output_text.delta → chat.completion.chunk
+//   - Translates non-streaming: output[].content[].text → choices[].message.content
+//
+// Endpoint: POST https://api.perplexity.ai/v1/agent
+// Auth: Bearer <pplx-...>
+
+const AGENT_URL = "https://api.perplexity.ai/v1/agent";
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+
+function errorResponse(status, message, code = "PERPLEXITY_AGENT_ERROR") {
+  return new Response(
+    JSON.stringify({ error: { message, type: "upstream_error", code } }),
+    { status, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+export class PerplexityAgentExecutor extends BaseExecutor {
+  constructor() {
+    super("perplexity-agent", null);
+  }
+
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+    const apiKey = credentials?.apiKey || "";
+    if (!apiKey) {
+      return {
+        response: errorResponse(401, "Perplexity Agent: no API key provided. Get one at perplexity.ai/settings/api."),
+        url: AGENT_URL, headers: {}, transformedBody: body,
+      };
+    }
+
+    // Flatten messages into input format for the Agent API
+    const messages = body?.messages || [];
+    const userMessages = messages.filter((m) => m.role === "user");
+    const sysMessages = messages.filter((m) => m.role === "system");
+    const lastUser = userMessages[userMessages.length - 1];
+    const userText = typeof lastUser?.content === "string"
+      ? lastUser.content
+      : Array.isArray(lastUser?.content)
+        ? lastUser.content.filter((c) => c.type === "text").map((c) => c.text).join("\n")
+        : "Hello";
+    const sysText = sysMessages.length > 0
+      ? (typeof sysMessages[0].content === "string" ? sysMessages[0].content : "")
+      : null;
+    const fullText = sysText ? `${sysText}\n\n${userText}` : userText;
+
+    const modelId = model || "openai/gpt-5-mini";
+
+    // Build Responses API request body
+    const agentBody = {
+      model: modelId,
+      input: fullText,
+      stream: !!stream,
+    };
+
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+      "User-Agent": USER_AGENT,
+      Accept: stream ? "text/event-stream" : "application/json",
+    };
+
+    log?.info?.("PPLX-AGENT", `model=${modelId} len=${fullText.length} stream=${stream}`);
+
+    let upstream;
+    try {
+      upstream = await proxyAwareFetch(AGENT_URL, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(agentBody),
+        signal,
+      }, proxyOptions);
+    } catch (err) {
+      if (err.name === "AbortError") throw err;
+      return {
+        response: errorResponse(502, `Perplexity Agent fetch failed: ${err?.message || err}`),
+        url: AGENT_URL, headers, transformedBody: agentBody,
+      };
+    }
+
+    if (upstream.status === 401 || upstream.status === 403) {
+      return {
+        response: errorResponse(401, "Perplexity Agent: invalid or expired API key."),
+        url: AGENT_URL, headers, transformedBody: agentBody,
+      };
+    }
+
+    if (!upstream.ok) {
+      const errText = await upstream.text().catch(() => "");
+      return {
+        response: errorResponse(upstream.status, `Perplexity Agent error: ${errText.slice(0, 300)}`),
+        url: AGENT_URL, headers, transformedBody: agentBody,
+      };
+    }
+
+    const cid = `chatcmpl-pplxa-${Date.now().toString(36)}`;
+    const created = Math.floor(Date.now() / 1000);
+
+    // Non-streaming: parse Responses API output
+    if (!stream) {
+      const data = await upstream.json().catch(() => ({}));
+      const content = data?.output?.map?.(o =>
+        o?.content?.map?.(c => c?.text || "").join("") || ""
+      ).join("") || "";
+      const reasoning = data?.output?.map?.(o =>
+        o?.content?.filter?.(c => c?.type === "reasoning").map(c => c?.text || "").join("")
+      ).join("") || "";
+      const usage = data?.usage || {};
+      const msg = { role: "assistant", content };
+      if (reasoning) msg.reasoning_content = reasoning;
+      return {
+        response: new Response(
+          JSON.stringify({
+            id: cid, object: "chat.completion", created, model: modelId,
+            choices: [{ index: 0, message: msg, finish_reason: "stop" }],
+            usage: {
+              prompt_tokens: usage.input_tokens || 0,
+              completion_tokens: usage.output_tokens || 0,
+              total_tokens: usage.total_tokens || 0,
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+        url: AGENT_URL, headers, transformedBody: agentBody,
+      };
+    }
+
+    // Streaming: translate Responses API events → OpenAI chat.completion.chunk
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const responseStream = new ReadableStream({
+      async start(controller) {
+        const reader = upstream.body.getReader();
+        let buffer = "";
+        let emittedFinish = false;
+
+        controller.enqueue(encoder.encode(sseChunk({
+          id: cid, object: "chat.completion.chunk", created, model: modelId,
+          choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+        })));
+
+        try {
+          while (true) {
+            if (signal?.aborted) break;
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() || "";
+
+            for (const line of lines) {
+              const trimmed = line.trim();
+              if (!trimmed || trimmed.startsWith("event:")) continue;
+              if (!trimmed.startsWith("data:")) continue;
+              const raw = trimmed.slice(5).trim();
+              if (raw === "[DONE]") continue;
+
+              try {
+                const evt = JSON.parse(raw);
+                const evtType = evt.type || "";
+
+                if (evtType === "response.output_text.delta" && evt.delta) {
+                  controller.enqueue(encoder.encode(sseChunk({
+                    id: cid, object: "chat.completion.chunk", created, model: modelId,
+                    choices: [{ index: 0, delta: { content: evt.delta }, finish_reason: null }],
+                  })));
+                } else if (evtType === "response.reasoning.delta" && evt.delta) {
+                  controller.enqueue(encoder.encode(sseChunk({
+                    id: cid, object: "chat.completion.chunk", created, model: modelId,
+                    choices: [{ index: 0, delta: { reasoning_content: evt.delta }, finish_reason: null }],
+                  })));
+                } else if ((evtType === "response.completed" || evtType === "response.failed") && !emittedFinish) {
+                  emittedFinish = true;
+                  controller.enqueue(encoder.encode(sseChunk({
+                    id: cid, object: "chat.completion.chunk", created, model: modelId,
+                    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                  })));
+                }
+              } catch { /* skip unparseable */ }
+            }
+          }
+        } catch (err) {
+          if (!signal?.aborted) controller.error(err);
+        } finally {
+          if (!emittedFinish && !signal?.aborted) {
+            controller.enqueue(encoder.encode(sseChunk({
+              id: cid, object: "chat.completion.chunk", created, model: modelId,
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            })));
+          }
+          try { reader.releaseLock?.(); } catch {}
+          controller.enqueue(encoder.encode(SSE_DONE));
+          controller.close();
+        }
+      },
+    });
+
+    return {
+      response: new Response(responseStream, { status: 200, headers: { ...SSE_HEADERS_NO_BUFFER } }),
+      url: AGENT_URL, headers, transformedBody: agentBody,
+    };
+  }
+}
+
+export default PerplexityAgentExecutor;

--- a/open-sse/executors/qwencloud.js
+++ b/open-sse/executors/qwencloud.js
@@ -1,0 +1,451 @@
+import { randomUUID } from "node:crypto";
+import { BaseExecutor } from "./base.js";
+import { SSE_DONE, SSE_HEADERS_NO_BUFFER } from "../utils/sseConstants.js";
+import { sseChunk } from "../utils/sse.js";
+import { tlsFetch } from "../utils/tlsClient.js";
+import { proxyAwareFetch } from "../utils/proxyFetch.js";
+
+// QwenCloud — Alibaba/Qwen consumer web chat executor.
+//
+// Multi-step auth flow:
+//   1. GET home.qwencloud.com/tool/user/info.json (cookie) → secToken
+//   2. POST cs-data.qwencloud.com (cookie + sec_token + bx-ua + bx-umidtoken) → accessToken
+//   3. POST cs-stream.qwencloud.com/sse/console4Json/{accessToken} (cookie) → SSE chat
+//
+// Auth input parsing:
+//   User pastes: "cookie=<cookie>; bx-ua=<value>; bx-umidtoken=<value>"
+//   Or just the cookie string. Without bx-ua/bx-umidtoken, accessToken
+//   generation will fail — the executor retries on each request.
+
+const USER_INFO_URL = "https://home.qwencloud.com/tool/user/info.json";
+const TOKEN_URL = "https://cs-data.qwencloud.com/data/api.json";
+const CHAT_BASE = "https://cs-stream.qwencloud.com/sse/console4Json";
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+
+// Per-process accessToken cache keyed by cookie hash.
+const TOKEN_CACHE = (global._qwencloudTokenCache ??= new Map());
+const TOKEN_TTL_MS = 25 * 60 * 1000; // 25 min
+
+function hashKey(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+
+// Parse user credential: "cookie=...; bx-ua=...; bx-umidtoken=..." or raw cookie
+function parseCredential(raw) {
+  const str = String(raw || "").trim();
+  let cookie = str;
+  let bxUa = "";
+  let bxUmidtoken = "";
+
+  // Extract bx-ua
+  const uaMatch = str.match(/bx-ua=([^\s;]+)/);
+  if (uaMatch) { bxUa = uaMatch[1]; cookie = cookie.replace(/bx-ua=[^\s;]+;?\s*/g, ""); }
+  // Extract bx-umidtoken
+  const umMatch = str.match(/bx-umidtoken=([^\s;]+)/);
+  if (umMatch) { bxUmidtoken = umMatch[1]; cookie = cookie.replace(/bx-umidtoken=[^\s;]+;?\s*/g, ""); }
+
+  // Clean up "cookie=" prefix if present
+  if (cookie.toLowerCase().startsWith("cookie:")) cookie = cookie.slice(7).trim();
+  cookie = cookie.replace(/^cookie=/i, "").trim();
+
+  return { cookie, bxUa, bxUmidtoken };
+}
+
+function errorResponse(status, message, code = "QWENCLOUD_ERROR") {
+  return new Response(
+    JSON.stringify({ error: { message, type: "upstream_error", code } }),
+    { status, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+// Step 1: Get secToken from user info
+async function getSecToken(cookie) {
+  const res = await tlsFetch(USER_INFO_URL, {
+    method: "GET",
+    headers: { Cookie: cookie, "User-Agent": USER_AGENT },
+  });
+  if (!res.ok) return null;
+  const data = await res.json().catch(() => null);
+  return data?.data?.secToken || null;
+}
+
+// Step 2: Get accessToken via cs-data API (requires bx-ua/bx-umidtoken)
+async function getAccessToken(cookie, secToken, bxUa, bxUmidtoken) {
+  const params = JSON.stringify({
+    Api: "zeldaEasy.cornerstoneStreamGateway.streamGatewayConsoleService.generateAccessToken",
+    Data: {
+      source: "",
+      cornerstoneParam: {
+        domain: "www.qwencloud.com",
+        consoleSite: "QWENCLOUD",
+        console: "ONE_CONSOLE",
+        xsp_lang: "en-US",
+        protocol: "V2",
+        productCode: "p_efm",
+        switchAgent: 1195760,
+      },
+    },
+    V: "1.0",
+  });
+
+  const formData = new URLSearchParams({
+    product: "sfm_bailian",
+    action: "IntlBroadScopeAspnGateway",
+    sec_token: secToken,
+    region: "ap-southeast-1",
+    params,
+  });
+
+  const headers = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Cookie: cookie,
+    "User-Agent": USER_AGENT,
+    Origin: "https://www.qwencloud.com",
+    Referer: "https://www.qwencloud.com/",
+    Accept: "application/json, text/plain, */*",
+  };
+  if (bxUa) headers["bx-ua"] = bxUa;
+  if (bxUmidtoken) headers["bx-umidtoken"] = bxUmidtoken;
+
+  const url = `${TOKEN_URL}?product=sfm_bailian&action=IntlBroadScopeAspnGateway&api=zeldaEasy.cornerstoneStreamGateway.streamGatewayConsoleService.generateAccessToken`;
+  const res = await tlsFetch(url, { method: "POST", headers, body: formData.toString() });
+  if (!res.ok) return null;
+  const data = await res.json().catch(() => null);
+  return data?.data?.DataV2?.data?.data?.accessToken || null;
+}
+
+// Cached token resolution
+async function resolveAccessToken(cookie, bxUa, bxUmidtoken) {
+  const key = hashKey(cookie);
+  const cached = TOKEN_CACHE.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.token;
+
+  const secToken = await getSecToken(cookie);
+  if (!secToken) return null;
+
+  const accessToken = await getAccessToken(cookie, secToken, bxUa, bxUmidtoken);
+  if (!accessToken) return null;
+
+  TOKEN_CACHE.set(key, { token: accessToken, expiresAt: Date.now() + TOKEN_TTL_MS });
+  return accessToken;
+}
+
+// Extract text from QwenCloud SSE event (accumulated format)
+// Each event contains full accumulated text in contentList[].content
+// contentList[0].type = "DeepThink" → reasoning, other = response
+function extractAccumulated(data) {
+  let reasoning = "";
+  let content = "";
+  let isDone = false;
+
+  const messages = data?.data?.messageList || [];
+  for (const msg of messages) {
+    if (msg.status === "FINISHED" || msg.status === "COMPLETE") isDone = true;
+    const parts = msg.contentList || [];
+    for (const part of parts) {
+      if (part.jsonPath === "/contentList/0/type" && part.content === "DeepThink") continue;
+      if (part.jsonPath === "/contentList/0/content") {
+        // Check if this is reasoning (first part type was "DeepThink") or response
+        const firstType = parts.find(p => p.jsonPath === "/contentList/0/type");
+        if (firstType?.content === "DeepThink") {
+          reasoning = part.content;
+        } else {
+          content = part.content;
+        }
+      }
+    }
+  }
+  return { content, reasoning, isDone };
+}
+
+export class QwenCloudExecutor extends BaseExecutor {
+  constructor() {
+    super("qwencloud", null);
+  }
+
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+    const { cookie, bxUa, bxUmidtoken } = parseCredential(credentials?.apiKey || "");
+    if (!cookie) {
+      return {
+        response: errorResponse(401, "QwenCloud: no cookie provided. Copy the full Cookie string from qwencloud.com DevTools."),
+        url: CHAT_BASE, headers: {}, transformedBody: body,
+      };
+    }
+
+    // Flatten messages
+    const messages = body?.messages || [];
+    const userMessages = messages.filter((m) => m.role === "user");
+    const sysMessages = messages.filter((m) => m.role === "system");
+    const lastUser = userMessages[userMessages.length - 1];
+    const userText = typeof lastUser?.content === "string"
+      ? lastUser.content
+      : Array.isArray(lastUser?.content)
+        ? lastUser.content.filter((c) => c.type === "text").map((c) => c.text).join("\n")
+        : "Hello";
+    const sysText = sysMessages.length > 0
+      ? (typeof sysMessages[0].content === "string" ? sysMessages[0].content : "")
+      : null;
+    const fullText = sysText ? `${sysText}\n\n${userText}` : userText;
+
+    const modelId = model || "qwen3.7-plus";
+    const fetchFn = proxyOptions?.connectionProxyEnabled ? proxyAwareFetch : tlsFetch;
+
+    // Resolve accessToken (cached)
+    let accessToken = await resolveAccessToken(cookie, bxUa, bxUmidtoken);
+    if (!accessToken) {
+      log?.warn?.("QWENCLOUD", "Failed to get accessToken — bx-ua/bx-umidtoken may be required or expired");
+      return {
+        response: errorResponse(401, "QwenCloud: failed to generate accessToken. Ensure bx-ua and bx-umidtoken are included in your credential. Re-copy from qwencloud.com DevTools → Network → POST to cs-data.qwencloud.com → Request Headers."),
+        url: CHAT_BASE, headers: {}, transformedBody: body,
+      };
+    }
+
+    // Build chat request
+    const messageId = randomUUID();
+    const sessionId = randomUUID().replace(/-/g, "");
+    const tabCode = randomUUID().replace(/-/g, "");
+
+    const predictRequest = {
+      modelId,
+      sessionId,
+      tabCode,
+      contentList: [{ type: "text", content: fullText }],
+      predictConfig: {
+        chatType: "t2t",
+        debug: null,
+        enableSearch: null,
+        extraParam: null,
+        featureParam: null,
+        frequencyPenalty: null,
+        gradioExtraParam: null,
+        maxLength: null,
+        modelParam: {
+          top_p: 0.8,
+          enable_thinking: true,
+          temperature: 0.7,
+          result_format: "message",
+          thinking_budget: 4000,
+          enable_search: false,
+        },
+        negativePrompt: null,
+        presencePenalty: null,
+        recordParam: null,
+        recorderMap: null,
+        stop: null,
+        systemMessage: null,
+        temperature: null,
+        topK: null,
+        topP: null,
+      },
+      reGenerate: false,
+      chatLogCode: messageId,
+      modelTypeIds: ["Reasoning", "TG", "VU"],
+      isAiCenterRequest: false,
+    };
+
+    const innerJson = JSON.stringify({
+      Api: "zeldaEasy.bmp.agentPredictRpcService.predict",
+      V: "1.0",
+      Data: { predictRequest },
+    });
+
+    const chatBody = JSON.stringify({
+      messageId,
+      data: [{ type: "JSON_TEXT", value: innerJson }],
+    });
+
+    const chatUrl = `${CHAT_BASE}/${accessToken}`;
+    const chatHeaders = {
+      "Content-Type": "application/json",
+      Cookie: cookie,
+      "User-Agent": USER_AGENT,
+      Origin: "https://www.qwencloud.com",
+      Referer: "https://www.qwencloud.com/",
+      Accept: "text/event-stream",
+    };
+
+    log?.info?.("QWENCLOUD", `model=${modelId} len=${fullText.length} stream=${stream}`);
+
+    let upstream;
+    try {
+      upstream = await fetchFn(chatUrl, { method: "POST", headers: chatHeaders, body: chatBody, signal }, proxyOptions);
+    } catch (err) {
+      if (err.name === "AbortError") throw err;
+      // Token might be expired — invalidate cache and retry once
+      TOKEN_CACHE.delete(hashKey(cookie));
+      return {
+        response: errorResponse(502, `QwenCloud fetch failed: ${err?.message || err}`),
+        url: chatUrl, headers: chatHeaders, transformedBody: chatBody,
+      };
+    }
+
+    if (upstream.status === 401 || upstream.status === 403) {
+      TOKEN_CACHE.delete(hashKey(cookie));
+      return {
+        response: errorResponse(401, "QwenCloud: session cookie or accessToken expired — re-copy from qwencloud.com DevTools."),
+        url: chatUrl, headers: chatHeaders, transformedBody: chatBody,
+      };
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      const errText = await upstream.text().catch(() => "");
+      return {
+        response: errorResponse(upstream.status || 502, `QwenCloud error: ${errText.slice(0, 300)}`),
+        url: chatUrl, headers: chatHeaders, transformedBody: chatBody,
+      };
+    }
+
+    const cid = `chatcmpl-qc-${randomUUID().slice(0, 12)}`;
+    const created = Math.floor(Date.now() / 1000);
+
+    // Non-streaming: collect all text
+    if (!stream) {
+      const { content, reasoning } = await collectQwenCloudText(upstream.body, signal);
+      const msg = { role: "assistant", content };
+      if (reasoning) msg.reasoning_content = reasoning;
+      return {
+        response: new Response(
+          JSON.stringify({
+            id: cid, object: "chat.completion", created, model: modelId,
+            choices: [{ index: 0, message: msg, finish_reason: "stop" }],
+            usage: { prompt_tokens: Math.ceil(fullText.length / 4), completion_tokens: Math.ceil(content.length / 4), total_tokens: 0 },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+        url: chatUrl, headers: chatHeaders, transformedBody: chatBody,
+      };
+    }
+
+    // Streaming: translate QwenCloud SSE → OpenAI chat.completion.chunk
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const responseStream = new ReadableStream({
+      async start(controller) {
+        const reader = upstream.body.getReader();
+        let buffer = "";
+        let lastContent = "";
+        let lastReasoning = "";
+        let emittedFinish = false;
+
+        controller.enqueue(encoder.encode(sseChunk({
+          id: cid, object: "chat.completion.chunk", created, model: modelId,
+          choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+        })));
+
+        try {
+          while (true) {
+            if (signal?.aborted) break;
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() || "";
+
+            for (const line of lines) {
+              const trimmed = line.trim();
+              if (!trimmed.startsWith("data:")) continue;
+              const raw = trimmed.slice(5).trim();
+              if (raw === "[DONE]") continue;
+
+              try {
+                const outer = JSON.parse(raw);
+                const innerRaw = outer?.data?.[0]?.value;
+                if (!innerRaw) continue;
+                const inner = JSON.parse(innerRaw);
+                const { content, reasoning, isDone } = extractAccumulated(inner);
+
+                // Emit delta (content is accumulated — send only new chars)
+                if (reasoning && reasoning.length > lastReasoning.length) {
+                  const delta = reasoning.slice(lastReasoning.length);
+                  lastReasoning = reasoning;
+                  controller.enqueue(encoder.encode(sseChunk({
+                    id: cid, object: "chat.completion.chunk", created, model: modelId,
+                    choices: [{ index: 0, delta: { reasoning_content: delta }, finish_reason: null }],
+                  })));
+                }
+                if (content && content.length > lastContent.length) {
+                  const delta = content.slice(lastContent.length);
+                  lastContent = content;
+                  controller.enqueue(encoder.encode(sseChunk({
+                    id: cid, object: "chat.completion.chunk", created, model: modelId,
+                    choices: [{ index: 0, delta: { content: delta }, finish_reason: null }],
+                  })));
+                }
+                if (isDone && !emittedFinish) {
+                  emittedFinish = true;
+                  controller.enqueue(encoder.encode(sseChunk({
+                    id: cid, object: "chat.completion.chunk", created, model: modelId,
+                    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                  })));
+                }
+              } catch { /* skip */ }
+            }
+          }
+        } catch (err) {
+          if (!signal?.aborted) controller.error(err);
+        } finally {
+          if (!emittedFinish && !signal?.aborted) {
+            controller.enqueue(encoder.encode(sseChunk({
+              id: cid, object: "chat.completion.chunk", created, model: modelId,
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            })));
+          }
+          try { reader.releaseLock?.(); } catch {}
+          controller.enqueue(encoder.encode(SSE_DONE));
+          controller.close();
+        }
+      },
+    });
+
+    return {
+      response: new Response(responseStream, { status: 200, headers: { ...SSE_HEADERS_NO_BUFFER } }),
+      url: chatUrl, headers: chatHeaders, transformedBody: chatBody,
+    };
+  }
+}
+
+/** Collect full text from QwenCloud SSE stream (accumulated format). */
+async function collectQwenCloudText(body, signal) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let content = "";
+  let reasoning = "";
+  let lastContent = "";
+  let lastReasoning = "";
+
+  try {
+    while (true) {
+      if (signal?.aborted) break;
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() || "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data:")) continue;
+        const raw = trimmed.slice(5).trim();
+        if (raw === "[DONE]") continue;
+        try {
+          const outer = JSON.parse(raw);
+          const innerRaw = outer?.data?.[0]?.value;
+          if (!innerRaw) continue;
+          const inner = JSON.parse(innerRaw);
+          const { content: c, reasoning: r } = extractAccumulated(inner);
+          if (c.length > lastContent.length) lastContent = c;
+          if (r.length > lastReasoning.length) lastReasoning = r;
+        } catch { /* skip */ }
+      }
+    }
+  } finally {
+    try { reader.releaseLock?.(); } catch {}
+  }
+  return { content: lastContent, reasoning: lastReasoning };
+}
+
+export default QwenCloudExecutor;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -27,6 +27,7 @@ import { dedupeTools } from "../utils/toolDeduper.js";
 // in-flight per connection at a time.
 const cookieRefreshInProgress = new Set();
 import { injectCaveman } from "../rtk/caveman.js";
+import { compressWithPxpipe, formatPxpipeLog, formatPxpipeSizeLog, isPxpipePhantomSavings } from "../rtk/pxpipe.js";
 import { injectPonytail } from "../rtk/ponytail.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
 import { compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog, isHeadroomPhantomSavings } from "../rtk/headroom.js";
@@ -41,7 +42,7 @@ import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking, semanticCacheEnabled, semanticCacheThreshold }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking, semanticCacheEnabled, semanticCacheThreshold, pxpipeEnabled, pxpipeDir, pxpipeMinChars, pxpipeTimeoutMs }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -55,7 +56,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Only applies to non-streaming, tool-free, sufficiently-long requests.
   if (semanticCacheEnabled && isCacheable(body, false, provider, model)) {
     const threshold = typeof semanticCacheThreshold === "number" ? semanticCacheThreshold : 0.85;
-    const cached = cacheLookup(provider, model, body, threshold);
+    // SECURITY: Partition cache by API key to prevent cross-user leakage
+    const cacheIdentity = apiKey || connectionId || "local";
+    const cached = cacheLookup(provider, model, body, threshold, cacheIdentity);
     if (cached) {
       log?.info?.("CACHE", `semantic cache ${cached.exact ? "HIT" : "near-hit"} (${(cached.similarity * 100).toFixed(0)}% similarity) — returning cached response`);
       const cachedResponse = cached.response.clone ? cached.response.clone() : cached.response;
@@ -138,7 +141,13 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     }
     // Convert remote image URLs to base64 for targets that can't fetch URLs.
     try {
-      const n = await prefetchRemoteImages(body, sourceFormat, targetFormat, { signal: undefined });
+      // C4 FIX: Pass a real abort signal with timeout (not undefined) to prevent
+      // indefinite hangs on slow/unresponsive image hosts. SSRF guard is applied
+      // inside fetchImageAsBase64 via resolvePinnedIps which validates resolved IPs.
+      const imgCtrl = new AbortController();
+      const imgTimer = setTimeout(() => imgCtrl.abort(), 10_000); // 10s max per prefetch
+      const n = await prefetchRemoteImages(body, sourceFormat, targetFormat, { signal: imgCtrl.signal, timeoutMs: 10_000 });
+      clearTimeout(imgTimer);
       if (n > 0) log?.debug?.("MODALITY", `prefetched ${n} remote image(s) for ${targetFormat}`);
     } catch (e) { log?.warn?.("MODALITY", `image prefetch failed: ${e.message}`); }
   }
@@ -213,13 +222,34 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     log?.debug?.("PONYTAIL", `${ponytailLevel} | ${finalFormat}`);
   }
 
-  // Compute total tokens saved by RTK + Headroom for this request.
-  // RTK measures bytes saved → approximate tokens (bytes/4).
-  // Headroom reports tokens_saved directly.
+  // Pxpipe: multimodal prompt compression — render dense Claude bodies as PNGs.
+  // Runs after Caveman/Ponytail so it compresses the final body including injected prompts.
+  // Only applies to Claude format; fail-open on any error.
+  const pxpipeDiagnostics = {};
+  const pxpipeStats = await compressWithPxpipe(translatedBody, {
+    enabled: pxpipeEnabled && finalFormat === "claude",
+    pxpipeDir,
+    minChars: pxpipeMinChars,
+    timeoutMs: pxpipeTimeoutMs,
+    diagnostics: pxpipeDiagnostics,
+  });
+  const pxpipeLine = formatPxpipeLog(pxpipeStats);
+  const pxpipeSizeLine = formatPxpipeSizeLog(pxpipeDiagnostics);
+  if (pxpipeLine) {
+    log?.info?.("PXPIPE", `${pxpipeLine}${pxpipeSizeLine ? ` | ${pxpipeSizeLine}` : ""}`);
+    if (isPxpipePhantomSavings(pxpipeStats, pxpipeDiagnostics)) {
+      log?.warn?.("PXPIPE", `reported token delta, but body barely shrank | ${pxpipeSizeLine}`);
+    }
+  } else if (pxpipeEnabled && finalFormat === "claude") {
+    log?.warn?.("PXPIPE", `skipped: ${pxpipeDiagnostics.reason || "unavailable"}`);
+  }
+
+  // Compute total tokens saved by RTK + Headroom + Pxpipe for this request.
   const rtkBytesSaved = rtkStats ? (rtkStats.bytesBefore || 0) - (rtkStats.bytesAfter || 0) : 0;
   const rtkTokensSaved = Math.round(rtkBytesSaved / 4);
   const headroomTokensSaved = headroomStats?.tokens_saved || 0;
-  const savedTokens = rtkTokensSaved + headroomTokensSaved;
+  const pxpipeTokensSaved = pxpipeStats?.tokensSaved || 0;
+  const savedTokens = rtkTokensSaved + headroomTokensSaved + pxpipeTokensSaved;
 
   const executor = getExecutor(provider);
   trackPendingRequest(model, provider, connectionId, true);
@@ -307,9 +337,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     // Semantic Cache — store successful non-streaming response for future lookups.
     if (semanticCacheEnabled && !stream && providerResponse?.ok && isCacheable(body, false, provider, model)) {
       try {
-        // Clone the response so we can both return it and cache it.
         const cloned = providerResponse.clone ? providerResponse.clone() : providerResponse;
-        cacheStore(provider, model, body, cloned);
+        const cacheIdentity = apiKey || connectionId || "local";
+        cacheStore(provider, model, body, cloned, undefined, cacheIdentity);
       } catch { /* fail-open: cache write failure should never break a request */ }
     }
   } catch (error) {

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -46,6 +46,7 @@ export const DEFAULT_CAPABILITIES = {
   thinkingFormat: null,
   thinkingCanDisable: true,  // false → model cannot turn thinking off (clamp to min instead of disable)
   thinkingRange: null,       // { min, max } for budget formats; null = no clamp
+  thinkingMaxEffort: false,  // true → supports "max" reasoning_effort (e.g. gpt-5.6-sol)
   // limits (tokens)
   contextWindow: 200000,
   maxOutput: 64000,
@@ -163,7 +164,7 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*gemini*image*",  caps: { vision: true, imageOutput: true, contextWindow: 1048576 } },
   { pattern: "*gemini-3*pro*",  caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65535 } },
   { pattern: "*gemini-3*",      caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65536 } },
-  { pattern: "*gemini-2.5*",    caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-budget", thinkingRange: { min: 0, max: 24576 }, contextWindow: 1048576, maxOutput: 65536 } },
+  { pattern: "*gemini-2.5*",    caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-budget", thinkingRange: { min: 1024, max: 24576 }, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini-2*",      caps: { vision: true, audioInput: true, videoInput: true, search: true, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini*",        caps: { vision: true, search: true, contextWindow: 1048576 } },
   { pattern: "*gemma*",         caps: { vision: true, contextWindow: 128000 } },
@@ -171,6 +172,10 @@ export const PATTERN_CAPABILITIES = [
 
   // ── OpenAI GPT-5.x (vision + thinking + web search) ──────────────
   { pattern: "*gpt-5*image*",   caps: { imageOutput: true } },
+  { pattern: "*gpt-5.6-sol*",  caps: { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 400000, maxOutput: 128000, thinkingMaxEffort: true } },
+
+  // ── Moonshot / Kimi K3 (reasoning, supports max effort) ──────────
+  { pattern: "*kimi-k3*",      caps: { vision: true, reasoning: true, thinkingFormat: "openai", contextWindow: 262144, maxOutput: 65536, thinkingMaxEffort: true } },
   { pattern: "*gpt-5*codex*",   caps: { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 400000, maxOutput: 128000 } },
   { pattern: "*gpt-5*",         caps: { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 400000, maxOutput: 128000 } },
   { pattern: "*gpt-4o*",        caps: { vision: true, search: true, contextWindow: 128000, maxOutput: 16384 } },

--- a/open-sse/providers/pricing.js
+++ b/open-sse/providers/pricing.js
@@ -28,6 +28,11 @@ export const MODEL_PRICING = {
   "claude-sonnet-4.6":            { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 22.50,  cache_creation: 3.00  },
   "claude-opus-4-5-thinking":     { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
   "claude-opus-4-6-thinking":     { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
+  "claude-opus-4.7":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
+  "claude-opus-4.8":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
+  "claude-sonnet-5":              { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 22.50,  cache_creation: 3.00  },
+  "claude-sonnet-5-thinking":     { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 22.50,  cache_creation: 3.00  },
+  "claude-fable-5":               { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 22.50,  cache_creation: 3.00  },
 
   // === OpenAI / GPT ===
   "gpt-3.5-turbo":                { input: 0.50,  output: 1.50,  cached: 0.25,  reasoning: 2.25,   cache_creation: 0.50  },
@@ -52,6 +57,13 @@ export const MODEL_PRICING = {
   "gpt-5.3-codex-low":           { input: 4.00,  output: 16.00, cached: 2.00,  reasoning: 24.00,  cache_creation: 4.00  },
   "gpt-5.3-codex-none":          { input: 3.00,  output: 12.00, cached: 1.50,  reasoning: 18.00,  cache_creation: 3.00  },
   "gpt-5.3-codex-spark":         { input: 3.00,  output: 12.00, cached: 0.30,  reasoning: 12.00,  cache_creation: 3.00  },
+  "gpt-5.4":                      { input: 6.00,  output: 24.00, cached: 3.00,  reasoning: 36.00,  cache_creation: 6.00  },
+  "gpt-5.4-mini":                 { input: 2.00,  output: 8.00,  cached: 1.00,  reasoning: 12.00,  cache_creation: 2.00  },
+  "gpt-5.4-nano":                 { input: 0.75,  output: 3.00,  cached: 0.375, reasoning: 4.50,   cache_creation: 0.75  },
+  "gpt-5.5":                      { input: 7.00,  output: 28.00, cached: 3.50,  reasoning: 42.00,  cache_creation: 7.00  },
+  "gpt-5.6-luna":                 { input: 8.00,  output: 32.00, cached: 4.00,  reasoning: 48.00,  cache_creation: 8.00  },
+  "gpt-5.6-sol":                  { input: 8.00,  output: 32.00, cached: 4.00,  reasoning: 48.00,  cache_creation: 8.00  },
+  "gpt-5.6-terra":                { input: 8.00,  output: 32.00, cached: 4.00,  reasoning: 48.00,  cache_creation: 8.00  },
   "o1":                           { input: 15.00, output: 60.00, cached: 7.50,  reasoning: 90.00,  cache_creation: 15.00 },
   "o1-mini":                      { input: 3.00,  output: 12.00, cached: 1.50,  reasoning: 18.00,  cache_creation: 3.00  },
 

--- a/open-sse/providers/registry/featherless.js
+++ b/open-sse/providers/registry/featherless.js
@@ -1,0 +1,52 @@
+// Featherless — HuggingFace model hosting via OpenAI-compatible API.
+//
+// Featherless provides access to 46,000+ open-source models hosted on
+// HuggingFace infrastructure through a single OpenAI-compatible endpoint.
+// Models include Llama, Qwen, Gemma, Mistral, DeepSeek, Phi, and many more.
+//
+// Endpoint: POST https://api.featherless.ai/v1/chat/completions
+// Models:   GET  https://api.featherless.ai/v1/models
+// Auth: Bearer <featherless-...>
+//
+// No custom executor needed — DefaultExecutor handles OpenAI-compatible APIs.
+// Model discovery at runtime via modelsFetcher (live /v1/models endpoint).
+export default {
+  id: "featherless",
+  priority: 290,
+  alias: "featherless",
+  aliases: ["fl"],
+  uiAlias: "fl",
+  display: {
+    name: "Featherless",
+    icon: "flutter_dash",
+    color: "#FF6B35",
+    textIcon: "FL",
+    website: "https://featherless.ai",
+    notice: {
+      signupUrl: "https://featherless.ai",
+      apiKeyUrl: "https://featherless.ai/account/api-keys",
+      text: "Featherless hosts 46,000+ open-source models from HuggingFace. Get a key at featherless.ai/account/api-keys. OpenAI-compatible — works with any standard client. Models are auto-discovered at runtime.",
+    },
+  },
+  category: "apikey",
+  authType: "apikey",
+  transport: {
+    baseUrl: "https://api.featherless.ai/v1/chat/completions",
+    format: "openai",
+    validateUrl: "https://api.featherless.ai/v1/models",
+  },
+  modelsFetcher: { url: "https://api.featherless.ai/v1/models?available_on_current_plan=true&per_page=100", type: "openai" },
+  // Seed models — offline fallback + popular picks. Full list discoverable at runtime.
+  models: [
+    { id: "meta-llama/Meta-Llama-3.1-8B-Instruct", name: "Llama 3.1 8B" },
+    { id: "meta-llama/Meta-Llama-3.1-70B-Instruct", name: "Llama 3.1 70B" },
+    { id: "Qwen/Qwen2.5-7B-Instruct", name: "Qwen 2.5 7B" },
+    { id: "Qwen/Qwen2.5-72B-Instruct", name: "Qwen 2.5 72B" },
+    { id: "google/gemma-2-9b-it", name: "Gemma 2 9B" },
+    { id: "mistralai/Mistral-7B-Instruct-v0.3", name: "Mistral 7B v0.3" },
+    { id: "mistralai/Mixtral-8x7B-Instruct-v0.1", name: "Mixtral 8x7B" },
+    { id: "deepseek-ai/deepseek-llm-7b-chat", name: "DeepSeek LLM 7B Chat" },
+    { id: "microsoft/Phi-3.5-mini-instruct", name: "Phi 3.5 Mini" },
+  ],
+  passthroughModels: true,
+};

--- a/open-sse/providers/registry/index.js
+++ b/open-sse/providers/registry/index.js
@@ -126,6 +126,10 @@ import p123 from "./zenmux-free.js";
 import p124 from "./api-airforce.js";
 import p125 from "./openvecta.js";
 import p126 from "./freebuff-web.js";
+import p127 from "./perplexity-agent.js";
+import p128 from "./featherless.js";
+import p129 from "./moonshot.js";
+import p130 from "./qwencloud.js";
 
 export default [
   p0,
@@ -254,5 +258,9 @@ export default [
   p123,
   p124,
   p125,
-  p126
+  p126,
+  p127,
+  p128,
+  p129,
+  p130
 ];

--- a/open-sse/providers/registry/moonshot.js
+++ b/open-sse/providers/registry/moonshot.js
@@ -1,0 +1,48 @@
+// Moonshot AI (api.moonshot.ai) — official Moonshot platform API for Kimi models.
+//
+// OpenAI-compatible endpoint at https://api.moonshot.ai/v1/chat/completions.
+// Supports kimi-k3 with reasoning_effort "max", plus kimi-k2.6, kimi-k2.5,
+// and vision models. Separate from the `kimi` (Coding Plan at api.kimi.com) and
+// `kimi-coding` providers.
+//
+// No custom executor needed — DefaultExecutor handles OpenAI-compatible APIs.
+// Reasoning_effort is passed through via the thinking layer (openai format).
+export default {
+  id: "moonshot",
+  priority: 165,
+  alias: "moonshot",
+  aliases: ["ms"],
+  uiAlias: "ms",
+  display: {
+    name: "Moonshot AI",
+    icon: "dark_mode",
+    color: "#6D28D9",
+    textIcon: "MS",
+    website: "https://platform.moonshot.ai",
+    notice: {
+      signupUrl: "https://platform.moonshot.ai/console/api-keys",
+      apiKeyUrl: "https://platform.moonshot.ai/console/api-keys",
+      text: "Moonshot AI is the official platform for Kimi models (kimi-k3, kimi-k2.6, kimi-k2.5). Get an API key at platform.moonshot.ai. OpenAI-compatible. kimi-k3 supports reasoning_effort: max.",
+    },
+  },
+  category: "apikey",
+  authType: "apikey",
+  thinkingConfig: {
+    options: ["auto", "none", "max"],
+    defaultMode: "auto",
+  },
+  transport: {
+    baseUrl: "https://api.moonshot.ai/v1/chat/completions",
+    format: "openai",
+    validateUrl: "https://api.moonshot.ai/v1/models",
+  },
+  models: [
+    { id: "kimi-k3", name: "Kimi K3" },
+    { id: "kimi-k2.6", name: "Kimi K2.6" },
+    { id: "kimi-k2.5", name: "Kimi K2.5" },
+    { id: "moonshot-v1-8k-vision-preview", name: "Moonshot v1 8K Vision" },
+    { id: "moonshot-v1-32k-vision-preview", name: "Moonshot v1 32K Vision" },
+    { id: "moonshot-v1-128k-vision-preview", name: "Moonshot v1 128K Vision" },
+  ],
+  passthroughModels: true,
+};

--- a/open-sse/providers/registry/perplexity-agent.js
+++ b/open-sse/providers/registry/perplexity-agent.js
@@ -1,0 +1,60 @@
+// Perplexity Agent — multi-model routing gateway via Perplexity's Agent API.
+//
+// Unlike the existing `perplexity` (Sonar, /chat/completions), the Agent API uses
+// Perplexity's OpenAI-compatible Responses API at POST /v1/agent. It routes to
+// 30+ third-party models (GPT, Claude, Gemini, Grok, GLM, Kimi, Sonar) through
+// a single Perplexity API key.
+//
+// Endpoint: POST https://api.perplexity.ai/v1/agent
+// Auth: Bearer <pplx-...>
+// Body: { input: string | array, model: "openai/gpt-5-mini", stream?: bool }
+//
+// Response format: OpenAI Responses API (output[].content[].text for non-streaming,
+// response.output_text.delta events for streaming).
+//
+// The PerplexityAgentExecutor (open-sse/executors/perplexity-agent.js) translates
+// OpenAI chat.completions requests to/from the Responses API format.
+export default {
+  id: "perplexity-agent",
+  priority: 175,
+  alias: "pplx-agent",
+  aliases: ["pplxa", "perplexity-agent"],
+  uiAlias: "pplxa",
+  display: {
+    name: "Perplexity Agent",
+    icon: "smart_toy",
+    color: "#20A39E",
+    textIcon: "PA",
+    website: "https://www.perplexity.ai",
+    notice: {
+      signupUrl: "https://www.perplexity.ai",
+      apiKeyUrl: "https://www.perplexity.ai/settings/api",
+      text: "Perplexity Agent API routes to 30+ third-party models (GPT, Claude, Gemini, Grok, GLM, Kimi, Sonar) through one Perplexity API key. Get a key at perplexity.ai/settings/api. Uses the Responses API format.",
+    },
+  },
+  category: "apikey",
+  authType: "apikey",
+  transport: {
+    baseUrl: "https://api.perplexity.ai/v1/agent",
+    format: "openai-responses",
+    validateUrl: "https://api.perplexity.ai/v1/models",
+  },
+  // Curated seed models — the full ~33 model list is discoverable at runtime
+  // via /v1/models. These cover the most popular models.
+  models: [
+    { id: "openai/gpt-5-mini", name: "GPT-5 Mini" },
+    { id: "openai/gpt-5", name: "GPT-5" },
+    { id: "openai/gpt-5.4", name: "GPT-5.4" },
+    { id: "openai/gpt-5.5", name: "GPT-5.5" },
+    { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { id: "anthropic/claude-opus-4-7", name: "Claude Opus 4.7" },
+    { id: "anthropic/claude-haiku-4-5", name: "Claude Haiku 4.5" },
+    { id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" },
+    { id: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash" },
+    { id: "xai/grok-4.20-multi-agent", name: "Grok 4.20 Multi-Agent" },
+    { id: "perplexity/glm-5.2", name: "GLM 5.2" },
+    { id: "perplexity/kimi-k2.7-code", name: "Kimi K2.7 Code" },
+    { id: "perplexity/sonar", name: "Sonar" },
+  ],
+  passthroughModels: true,
+};

--- a/open-sse/providers/registry/qwencloud.js
+++ b/open-sse/providers/registry/qwencloud.js
@@ -1,0 +1,46 @@
+// QwenCloud — Alibaba/Qwen consumer web chat (www.qwencloud.com).
+//
+// QwenCloud provides access to Qwen models (qwen3.7-plus, qwen3.7-max) via
+// a multi-step auth flow:
+//   1. Cookie auth (login_qwencloud_ticket)
+//   2. secToken from user/info.json
+//   3. accessToken from cs-data.qwencloud.com (requires bx-ua/bx-umidtoken anti-bot headers)
+//   4. Chat via SSE at cs-stream.qwencloud.com/sse/console4Json/{accessToken}
+//
+// The QwenCloudExecutor handles this flow, caching accessToken per session.
+//
+// Auth input: user pastes cookie + bx-ua + bx-umidtoken from DevTools.
+// Format: "cookie=<full_cookie>; bx-ua=<bx_ua_value>; bx-umidtoken=<umidtoken_value>"
+// Or just the cookie — accessToken generation will fail gracefully and retry.
+export default {
+  id: "qwencloud",
+  priority: 65,
+  alias: "qc",
+  aliases: ["qwencloud"],
+  uiAlias: "qc",
+  display: {
+    name: "QwenCloud",
+    icon: "cloud",
+    color: "#615CED",
+    textIcon: "QC",
+    website: "https://www.qwencloud.com",
+    notice: {
+      signupUrl: "https://www.qwencloud.com",
+      apiKeyUrl: "https://www.qwencloud.com",
+      text: "QwenCloud provides access to Qwen 3.7 models via web chat. Log in at qwencloud.com, open the chat at qwencloud.com/try-ai/chat?models=qwen3.7-max, then copy the FULL Cookie string + bx-ua + bx-umidtoken from DevTools. The executor handles the multi-step auth flow automatically.",
+    },
+  },
+  category: "webCookie",
+  authType: "cookie",
+  authHint: "Paste your cookie string from qwencloud.com (must include login_qwencloud_ticket). Optionally append: ; bx-ua=<value>; bx-umidtoken=<value> for accessToken generation.",
+  transport: {
+    baseUrl: "https://cs-stream.qwencloud.com/sse/console4Json",
+    format: "qwencloud",
+    authType: "cookie",
+  },
+  models: [
+    { id: "qwen3.7-max", name: "Qwen 3.7 Max" },
+    { id: "qwen3.7-plus", name: "Qwen 3.7 Plus" },
+  ],
+  passthroughModels: true,
+};

--- a/open-sse/rtk/autodetect.js
+++ b/open-sse/rtk/autodetect.js
@@ -90,8 +90,10 @@ function isGrepLine(line) {
 function isPathLike(line) {
   const t = line.trim();
   if (t.length === 0) return false;
-  if (t.includes(":")) return false;
-  return t.startsWith(".") || t.startsWith("/") || t.includes("/");
+  // Allow Windows drive-letter paths like C:\Users\... (colon at position 1 + backslash)
+  const isWinPath = /^[A-Za-z]:[\\/]/.test(t);
+  if (t.includes(":") && !isWinPath) return false;
+  return t.startsWith(".") || t.startsWith("/") || t.includes("/") || t.includes("\\") || isWinPath;
 }
 
 function isMostlyPorcelain(head) {

--- a/open-sse/rtk/filters/find.js
+++ b/open-sse/rtk/filters/find.js
@@ -9,7 +9,7 @@ export function find(input) {
   const byDir = new Map();
 
   for (const path of lines) {
-    const lastSlash = path.lastIndexOf("/");
+    const lastSlash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
     let dir;
     let basename;
     if (lastSlash === -1) {

--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -171,6 +171,46 @@ export async function compressWithHeadroom(body, { enabled, url, model, format, 
       return data;
     }
 
+    // Kiro shape: conversationState holds history + currentMessage.
+    // Flatten to OpenAI messages, compress, then rebuild conversationState.
+    if (format === "kiro" && body?.conversationState) {
+      const cs = body.conversationState;
+      const history = cs.history || [];
+      const messages = [];
+      for (const turn of history) {
+        if (turn.role === "user" && turn.userInputMessageContext?.toolResults) {
+          // Flatten tool results into text
+          for (const tr of turn.userInputMessageContext.toolResults) {
+            if (tr.content?.text) messages.push({ role: "user", content: tr.content.text });
+          }
+        } else if (turn.role === "assistant" && turn.assistantResponse?.content) {
+          for (const part of turn.assistantResponse.content) {
+            if (part.text) messages.push({ role: "assistant", content: part.text });
+          }
+        }
+      }
+      // Add current message
+      const currentText = cs.currentMessage?.userInputMessageContext?.inputMessage?.blocks
+        ?.filter((b) => b.text?.content).map((b) => b.text.content).join("\n");
+      if (currentText) messages.push({ role: "user", content: currentText });
+
+      if (messages.length === 0) {
+        setDiagnostic(diagnostics, "kiro conversationState yielded no messages");
+        return null;
+      }
+      const data = await callCompress(url, messages, model, timeoutMs, compressUserMessages, diagnostics || {});
+      if (!data) return null;
+      // Replace the largest text-heavy message in the current message with compressed version.
+      const lastUserIdx = messages.length - 1;
+      if (cs.currentMessage?.userInputMessageContext?.inputMessage?.blocks) {
+        const blocks = cs.currentMessage.userInputMessageContext.inputMessage.blocks;
+        const textBlock = blocks.find((b) => b.text?.content);
+        if (textBlock?.text) textBlock.text.content = messages[lastUserIdx]?.content || textBlock.text.content;
+      }
+      if (diagnostics) diagnostics.after = captureSizeSnapshot(body);
+      return data;
+    }
+
     // OpenAI shape: messages/input go straight to the proxy.
     const key = Array.isArray(body.messages) ? "messages"
       : Array.isArray(body.input) ? "input"

--- a/open-sse/rtk/pxpipe.js
+++ b/open-sse/rtk/pxpipe.js
@@ -1,0 +1,236 @@
+// Pxpipe — multimodal prompt compression via the pxpipe-proxy library.
+//
+// Renders dense Claude-format request bodies as PNG images before dispatch,
+// cutting estimated input tokens by ~35-60% on token-dense contexts.
+//
+// Unlike Headroom (which calls an external HTTP proxy), pxpipe loads the
+// npm package's library entry (transformAnthropicMessages) in-process.
+// This preserves ExtremeRouter's account fallback, OAuth credential injection,
+// and multi-provider routing — the package never touches the network itself.
+//
+// Integration follows the existing Headroom pattern:
+//   - Applied to the final body in chatCore just before dispatch
+//   - Fail-open on any error/timeout (never blocks a request)
+//   - Only applies to Claude-format bodies above a configurable size threshold
+//   - Token estimates use remaining-text/4 + pixels/750 (Anthropic image billing)
+//
+// Reference: github.com/pxpipe/pxpipe-proxy (transform library API)
+
+const DEFAULT_MIN_CHARS = 25_000;
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+// In-process module cache — the pxpipe package is dynamically loaded from
+// DATA_DIR/pxpipe (managed install). Survives hot-reload via global.
+let _pxpipeModule = null;
+let _pxpipeVersion = null;
+
+/**
+ * Load the pxpipe transform module from the managed install directory.
+ * Returns the module's exports or null if not installed/fail-open.
+ *
+ * @param {string} pxpipeDir — absolute path to the pxpipe install directory
+ * @returns {Promise<object|null>}
+ */
+export async function loadPxpipeModule(pxpipeDir) {
+  if (_pxpipeModule && _pxpipeVersion) return _pxpipeModule;
+  if (!pxpipeDir) return null;
+
+  try {
+    const { createRequire } = /* @vite-ignore */ await import(/* webpackIgnore: true */ "node:module");
+    const { pathToFileURL } = /* @vite-ignore */ await import(/* webpackIgnore: true */ "node:url");
+    const req = createRequire(import.meta.url);
+    const entryPath = req.resolve("pxpipe-proxy/transform", { paths: [pxpipeDir] });
+    const mod = await /* @vite-ignore */ import(/* webpackIgnore: true */ pathToFileURL(entryPath).href);
+    _pxpipeModule = mod;
+    _pxpipeVersion = mod.version || "unknown";
+    return mod;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Unload the cached pxpipe module (used by /api/pxpipe/stop).
+ */
+export function unloadPxpipeModule() {
+  _pxpipeModule = null;
+  _pxpipeVersion = null;
+}
+
+/**
+ * Check if the pxpipe module is loaded (for status endpoint).
+ */
+export function isPxpipeLoaded() {
+  return _pxpipeModule !== null;
+}
+
+/**
+ * Estimate the character count of a Claude-format request body's text content.
+ * Only counts text blocks — not images, not tool schemas, not metadata.
+ */
+function estimateBodyChars(body) {
+  if (!body?.messages) return 0;
+  let chars = 0;
+  for (const msg of body.messages) {
+    if (typeof msg.content === "string") {
+      chars += msg.content.length;
+    } else if (Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          chars += block.text.length;
+        } else if (block.type === "tool_result" && typeof block.content === "string") {
+          chars += block.content.length;
+        } else if (block.type === "tool_result" && Array.isArray(block.content)) {
+          for (const part of block.content) {
+            if (part.type === "text" && typeof part.text === "string") chars += part.text.length;
+          }
+        }
+      }
+    }
+  }
+  return chars;
+}
+
+/**
+ * Estimate input tokens from text characters + image pixels.
+ * Anthropic bills: text at ~4 chars/token, images at ~750 tokens per image
+ * (depending on resolution, but this is a conservative average).
+ */
+function estimateInputTokens(body, imageCount = 0) {
+  const textChars = estimateBodyChars(body);
+  return Math.ceil(textChars / 4) + imageCount * 750;
+}
+
+/**
+ * Compress a Claude-format request body using pxpipe.
+ *
+ * Mutates `body` in place (messages replaced with image blocks where profitable).
+ * Returns stats object on success, or null on any failure (fail-open).
+ *
+ * @param {object} body — the request body (Claude format)
+ * @param {object} opts
+ * @param {boolean} opts.enabled — master toggle
+ * @param {string} opts.pxpipeDir — path to managed pxpipe install
+ * @param {number} opts.minChars — minimum text chars to trigger compression (default: 25000)
+ * @param {number} opts.timeoutMs — compression timeout (default: 5000)
+ * @param {object} opts.diagnostics — optional caller-owned diagnostics object
+ * @returns {Promise<object|null>} stats: { tokensBefore, tokensAfter, tokensSaved, imageCount, skipReason }
+ */
+export async function compressWithPxpipe(body, {
+  enabled,
+  pxpipeDir,
+  minChars = DEFAULT_MIN_CHARS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  diagnostics = null,
+} = {}) {
+  const setDiag = (d, reason) => { if (d) d.reason = reason; };
+
+  if (!enabled) { setDiag(diagnostics, "disabled"); return null; }
+  if (!body?.messages) { setDiag(diagnostics, "no messages"); return null; }
+
+  // Gate: only Claude format. pxpipe's transformAnthropicMessages expects Claude shape.
+  // The caller (chatCore) should only pass Claude-format bodies.
+  if (!body.messages || !Array.isArray(body.messages)) {
+    setDiag(diagnostics, "not claude format");
+    return null;
+  }
+
+  // Gate: size threshold. Don't compress small bodies — overhead isn't worth it.
+  const charCount = estimateBodyChars(body);
+  if (charCount < minChars) {
+    setDiag(diagnostics, `below threshold (${charCount} < ${minChars} chars)`);
+    return null;
+  }
+
+  // Load the module
+  const mod = await loadPxpipeModule(pxpipeDir);
+  if (!mod) {
+    setDiag(diagnostics, "pxpipe not installed");
+    return null;
+  }
+
+  if (typeof mod.transformAnthropicMessages !== "function") {
+    setDiag(diagnostics, "pxpipe module missing transformAnthropicMessages export");
+    return null;
+  }
+
+  const tokensBefore = estimateInputTokens(body, 0);
+
+  try {
+    // Race the transform against a timeout — fail-open if it takes too long.
+    const result = await Promise.race([
+      mod.transformAnthropicMessages(body),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("pxpipe timeout")), timeoutMs),
+      ),
+    ]);
+
+    // The transform returns { messages, skipReason?, meta? } or modifies body in place.
+    // Handle both patterns.
+    if (result?.skipReason) {
+      setDiag(diagnostics, `skipped by library: ${result.skipReason}`);
+      return null;
+    }
+
+    // If the transform returned new messages, apply them.
+    if (result?.messages) {
+      body.messages = result.messages;
+    }
+
+    // Count images in the transformed body for token estimation.
+    let imageCount = 0;
+    for (const msg of body.messages) {
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block.type === "image" || (block.source?.type === "base64")) imageCount++;
+        }
+      }
+    }
+
+    const tokensAfter = estimateInputTokens(body, imageCount);
+    const tokensSaved = Math.max(0, tokensBefore - tokensAfter);
+
+    if (diagnostics) {
+      diagnostics.before = tokensBefore;
+      diagnostics.after = tokensAfter;
+    }
+
+    return {
+      tokensBefore,
+      tokensAfter,
+      tokensSaved,
+      imageCount,
+      charCount,
+    };
+  } catch (error) {
+    setDiag(diagnostics, `error: ${error?.message || String(error)}`);
+    return null;
+  }
+}
+
+/**
+ * Format pxpipe stats for console log.
+ */
+export function formatPxpipeLog(stats) {
+  if (!stats || !stats.tokensSaved) return null;
+  return `pxpipe saved ${stats.tokensSaved.toLocaleString()} tokens (${stats.tokensBefore.toLocaleString()} → ${stats.tokensAfter.toLocaleString()}, ${stats.imageCount} images)`;
+}
+
+/**
+ * Format pxpipe size for diagnostic log.
+ */
+export function formatPxpipeSizeLog(diagnostics) {
+  if (!diagnostics?.before || !diagnostics?.after) return null;
+  const pct = diagnostics.before > 0 ? Math.round((1 - diagnostics.after / diagnostics.before) * 100) : 0;
+  return `${diagnostics.before.toLocaleString()} → ${diagnostics.after.toLocaleString()} tokens (-${pct}%)`;
+}
+
+/**
+ * Detect phantom savings (library claims savings but body barely changed).
+ */
+export function isPxpipePhantomSavings(stats, diagnostics, minShrinkRatio = 0.05) {
+  if (!stats || !diagnostics?.before || !diagnostics?.after) return false;
+  if (stats.tokensSaved <= 0) return false;
+  const shrinkRatio = 1 - diagnostics.after / diagnostics.before;
+  return shrinkRatio < minShrinkRatio;
+}

--- a/open-sse/services/circuitBreaker.js
+++ b/open-sse/services/circuitBreaker.js
@@ -101,6 +101,9 @@ export function isCircuitOpen(provider, settings = {}) {
     if (b.halfOpenCalls >= cfg.halfOpenMaxCalls) {
       return true; // probe in flight → block additional traffic
     }
+    // H1 FIX: Atomically claim a probe slot so concurrent requests can't all
+    // pass the half-open gate simultaneously (synchronous = no interleaving).
+    b.halfOpenCalls++;
   }
 
   return false; // CLOSED or HALF_OPEN with capacity → allow
@@ -160,6 +163,20 @@ export function recordBreakerFailure(provider, status, settings = {}) {
     }
   }
   // If already OPEN, ignore (we don't count failures while blocked).
+}
+
+/**
+ * Release a claimed half-open probe slot without recording success or failure.
+ * Use this when a request that passed the half-open gate is aborted or throws
+ * an unhandled exception before reaching recordBreakerSuccess/Failure.
+ * Without this, the slot leaks and the breaker sticks at capacity indefinitely.
+ */
+export function releaseBreakerProbe(provider) {
+  const b = monitors.get(provider);
+  if (!b || b.state !== "halfOpen") return;
+  if (b.halfOpenCalls > 0) {
+    b.halfOpenCalls--;
+  }
 }
 
 /**

--- a/open-sse/services/semanticCache.js
+++ b/open-sse/services/semanticCache.js
@@ -72,11 +72,13 @@ function extractCacheableText(messages) {
 
 /**
  * Build a cache key from provider + model + normalized message text hash.
+ * SECURITY: Includes a hash of the API key to prevent cross-user cache leakage.
+ * Without this, user A's cached response could be served to user B in multi-user deployments.
  */
-function buildCacheKey(provider, model, text) {
+function buildCacheKey(provider, model, text, identity = "") {
   // Simple FNV-1a hash (no crypto needed for cache keys)
   let hash = 2166136261;
-  const str = `${provider}::${model}::${text}`;
+  const str = `${identity}::${provider}::${model}::${text}`;
   for (let i = 0; i < str.length; i++) {
     hash ^= str.charCodeAt(i);
     hash = Math.imul(hash, 16777619);
@@ -115,11 +117,11 @@ export function isCacheable(body, stream, provider, model) {
  * @param {number} threshold - Jaccard threshold for near-match (0..1)
  * @returns {{ response: object, similarity: number, exact: boolean } | null}
  */
-export function cacheLookup(provider, model, body, threshold = DEFAULT_THRESHOLD) {
+export function cacheLookup(provider, model, body, threshold = DEFAULT_THRESHOLD, identity = "") {
   const text = extractCacheableText(body.messages);
   if (!text) { STATS.misses++; return null; }
 
-  const key = buildCacheKey(provider, model, text);
+  const key = buildCacheKey(provider, model, text, identity);
   const now = Date.now();
 
   // 1. Exact match
@@ -142,6 +144,9 @@ export function cacheLookup(provider, model, body, threshold = DEFAULT_THRESHOLD
       STATS.evicted++;
       continue;
     }
+    // SECURITY: Only match entries from the same identity (API key) to prevent
+    // cross-user cache leakage.
+    if (entry.identity !== identity) continue;
     if (entry.provider !== provider || entry.model !== model) continue;
 
     const sim = jaccardSimilarity(queryTokens, entry.tokenSet);
@@ -170,11 +175,11 @@ export function cacheLookup(provider, model, body, threshold = DEFAULT_THRESHOLD
  * @param {object} response - the response data to cache
  * @param {number} ttlMs - time-to-live in milliseconds
  */
-export function cacheStore(provider, model, body, response, ttlMs = DEFAULT_TTL_MS) {
+export function cacheStore(provider, model, body, response, ttlMs = DEFAULT_TTL_MS, identity = "") {
   const text = extractCacheableText(body.messages);
   if (!text) return;
 
-  const key = buildCacheKey(provider, model, text);
+  const key = buildCacheKey(provider, model, text, identity);
   const now = Date.now();
 
   // Evict expired entries (lazy GC)
@@ -197,6 +202,7 @@ export function cacheStore(provider, model, body, response, ttlMs = DEFAULT_TTL_
   CACHE.set(key, {
     provider,
     model,
+    identity,
     response,
     tokenSet: tokenize(text),
     text,

--- a/open-sse/translator/concerns/image.js
+++ b/open-sse/translator/concerns/image.js
@@ -1,4 +1,6 @@
 // Build a base64 data URI from mime + base64 payload
+import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
+
 export function encodeDataUri(mimeType, base64) {
   return `data:${mimeType};base64,${base64}`;
 }
@@ -81,6 +83,8 @@ export async function fetchImageAsBase64(imageUrl, options = {}) {
 
   let url;
   try { url = new URL(imageUrl); } catch { return null; }
+  // C4 FIX: SSRF guard — block internal/private IPs before DNS resolution
+  try { assertPublicUrl(imageUrl); } catch { return null; }
   const pinnedIps = await resolvePinnedIps(url.hostname);
   if (!pinnedIps) return null;
 

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -305,6 +305,12 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
   } else {
     // Keep safetySettings for Gemini CLI
     envelope.request.safetySettings = geminiCLI.safetySettings;
+    // Also emit validated toolConfig for Gemini CLI when tools are present
+    if (geminiCLI.tools?.length > 0) {
+      envelope.request.toolConfig = {
+        functionCallingConfig: { mode: "VALIDATED" }
+      };
+    }
   }
 
   return envelope;

--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -1,6 +1,7 @@
 import { Readable } from "stream";
 import { MEMORY_CONFIG } from "../config/runtimeConfig.js";
 import { dbg } from "./debugLog.js";
+import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
 
 const originalFetch = globalThis.fetch;
 const proxyDispatchers = new Map();
@@ -300,6 +301,8 @@ export async function proxyAwareFetch(url, options = {}, proxyOptions = null) {
   // Vercel relay: forward request via relay headers
   const vercelRelayUrl = normalizeString(proxyOptions?.vercelRelayUrl);
   if (vercelRelayUrl) {
+    // C1 FIX: SSRF guard — validate relay URL is not internal/private
+    try { assertPublicUrl(vercelRelayUrl); } catch { throw new Error("Blocked relay URL: internal/private host"); }
     const parsed = new URL(targetUrl);
     const relayHeaders = {
       ...options.headers,
@@ -310,6 +313,10 @@ export async function proxyAwareFetch(url, options = {}, proxyOptions = null) {
   }
 
   const connectionProxyUrl = resolveConnectionProxyUrl(targetUrl, proxyOptions);
+  // C1 FIX: SSRF guard — validate connection proxy URL is not internal/private
+  if (connectionProxyUrl) {
+    try { assertPublicUrl(connectionProxyUrl); } catch { throw new Error("Blocked proxy URL: internal/private host"); }
+  }
   const envProxyUrl = connectionProxyUrl ? null : normalizeProxyUrl(getEnvProxyUrl(targetUrl));
   const proxyUrl = connectionProxyUrl || envProxyUrl;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsalmn/extremerouter-app",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "ExtremeRouter web dashboard",
   "private": true,
   "license": "MIT",

--- a/public/providers/featherless.svg
+++ b/public/providers/featherless.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="14" fill="#0D0D1A"/>
+  <!-- Feather symbol representing "Featherless" (lightweight models) -->
+  <path d="M20 48 Q20 30 36 18 Q44 12 48 16 Q44 20 40 26 Q36 32 34 38 Q32 44 28 46 Q24 48 20 48 Z" fill="#FF6B35"/>
+  <path d="M20 48 L14 56" stroke="#FF6B35" stroke-width="3" stroke-linecap="round"/>
+  <line x1="24" y1="44" x2="38" y2="30" stroke="#0D0D1A" stroke-width="1.5" opacity="0.4"/>
+  <line x1="28" y1="40" x2="42" y2="26" stroke="#0D0D1A" stroke-width="1.5" opacity="0.4"/>
+</svg>

--- a/public/providers/moonshot.svg
+++ b/public/providers/moonshot.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="14" fill="#0D0D1A"/>
+  <!-- Crescent moon representing "Moonshot" -->
+  <path d="M44 32 A16 16 0 1 1 28 16 A12 12 0 0 0 44 32 Z" fill="#6D28D9"/>
+  <circle cx="44" cy="20" r="2.5" fill="#A78BFA" opacity="0.6"/>
+  <circle cx="50" cy="28" r="1.5" fill="#A78BFA" opacity="0.4"/>
+  <circle cx="48" cy="14" r="1" fill="#A78BFA" opacity="0.5"/>
+</svg>

--- a/public/providers/perplexity-agent.svg
+++ b/public/providers/perplexity-agent.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="14" fill="#0D0D1A"/>
+  <!-- Agent/multi-model symbol: interconnected nodes representing routing -->
+  <circle cx="32" cy="14" r="5" fill="#20A39E"/>
+  <circle cx="16" cy="38" r="5" fill="#20A39E" opacity="0.7"/>
+  <circle cx="48" cy="38" r="5" fill="#20A39E" opacity="0.7"/>
+  <circle cx="32" cy="50" r="5" fill="#20A39E" opacity="0.5"/>
+  <line x1="32" y1="14" x2="16" y2="38" stroke="#20A39E" stroke-width="2" opacity="0.5"/>
+  <line x1="32" y1="14" x2="48" y2="38" stroke="#20A39E" stroke-width="2" opacity="0.5"/>
+  <line x1="16" y1="38" x2="32" y2="50" stroke="#20A39E" stroke-width="2" opacity="0.4"/>
+  <line x1="48" y1="38" x2="32" y2="50" stroke="#20A39E" stroke-width="2" opacity="0.4"/>
+  <line x1="16" y1="38" x2="48" y2="38" stroke="#20A39E" stroke-width="2" opacity="0.3"/>
+</svg>

--- a/public/providers/qwencloud.svg
+++ b/public/providers/qwencloud.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="14" fill="#0D0D1A"/>
+  <!-- Cloud symbol representing "QwenCloud" -->
+  <path d="M20 40 Q12 40 12 32 Q12 26 18 25 Q20 18 28 18 Q36 18 38 25 Q46 25 46 33 Q46 40 38 40 Z" fill="#615CED"/>
+  <path d="M20 40 Q12 40 12 32 Q12 26 18 25 Q20 18 28 18 Q36 18 38 25 Q46 25 46 33 Q46 40 38 40 Z" fill="#818CF8" opacity="0.4"/>
+</svg>

--- a/src/app/(dashboard)/dashboard/alerts/page.js
+++ b/src/app/(dashboard)/dashboard/alerts/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Card, Button, Input, Toggle, PageHeader, Badge } from "@/shared/components";
 
 const EVENT_OPTIONS = [
@@ -30,20 +30,36 @@ export default function AlertsPage() {
 
   useEffect(() => { fetchSettings(); }, [fetchSettings]);
 
+  // Cleanup: clear debounce timer on unmount to prevent state updates on unmounted component
+  useEffect(() => () => { if (patchTimer.current) clearTimeout(patchTimer.current); }, []);
+
+  // H4 FIX: Use a ref to always read the latest settings when building the PATCH
+  // body, avoiding stale closure on concurrent keystrokes. Debounce the actual
+  // network call to prevent data loss from rapid successive writes.
+  const patchTimer = useRef(null);
   const patch = useCallback(async (key, value, subKey) => {
-    const body = subKey
-      ? { [key]: { ...(settings[key] || {}), [subKey]: value } }
-      : { [key]: value };
-    setSettings(prev => subKey
-      ? { ...prev, [key]: { ...(prev?.[key] || {}), [subKey]: value } }
-      : { ...prev, [key]: value }
-    );
-    try {
-      await fetch("/api/settings", { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
-      setSavedField(subKey || key);
-      setTimeout(() => setSavedField(null), 1500);
-    } catch { /* non-fatal */ }
-  }, [settings]);
+    // Build body from current settings state (functional read)
+    setSettings(prev => {
+      const updated = subKey
+        ? { ...prev, [key]: { ...(prev?.[key] || {}), [subKey]: value } }
+        : { ...prev, [key]: value };
+      // Debounce the network write: clear any pending write and schedule a new one
+      if (patchTimer.current) clearTimeout(patchTimer.current);
+      patchTimer.current = setTimeout(async () => {
+        try {
+          const body = subKey
+            ? { [key]: { ...(updated[key] || {}), [subKey]: value } }
+            : { [key]: value };
+          const res = await fetch("/api/settings", { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+          if (res.ok) {
+            setSavedField(subKey || key);
+            setTimeout(() => setSavedField(null), 1500);
+          }
+        } catch { /* non-fatal */ }
+      }, 500); // 500ms debounce
+      return updated;
+    });
+  }, []);
 
   const handleTest = async () => {
     setTesting(true);

--- a/src/app/(dashboard)/dashboard/combos/CombosPageInner.js
+++ b/src/app/(dashboard)/dashboard/combos/CombosPageInner.js
@@ -86,7 +86,8 @@ export default function CombosPageInner() {
         setConfirmState(null);
         try {
           const res = await fetch(`/api/combos/${id}`, { method: "DELETE" });
-          if (res.ok) setCombos(combos.filter((c) => c.id !== id));
+          // H5 FIX: Use functional update to avoid stale closure on `combos`
+          if (res.ok) setCombos(prev => prev.filter((c) => c.id !== id));
         } catch (error) { console.log("Error deleting combo:", error); }
       },
     });

--- a/src/app/(dashboard)/dashboard/overview/components/FreeProvidersGrid.js
+++ b/src/app/(dashboard)/dashboard/overview/components/FreeProvidersGrid.js
@@ -11,7 +11,7 @@ const SVG_ICON_IDS = new Set([
   "chatgpt-web", "doubao-web", "gemini-web", "copilot-web", "muse-spark-web",
   "duckduckgo-web", "venice-web", "t3-web", "lmarena", "veoaifree-web",
   "claude-web", "pollinations", "poe-web", "v0-vercel-web", "qwen-web",
-  "kimi-web", "huggingchat", "api-airforce", "openvecta", "freebuff-web", "zenmux-free",
+  "kimi-web", "huggingchat", "api-airforce", "openvecta", "freebuff-web", "zenmux-free", "perplexity-agent", "featherless", "moonshot", "qwencloud",
 ]);
 
 const fmt = (n) => {

--- a/src/app/(dashboard)/dashboard/providers/[id]/HealthTimeline.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/HealthTimeline.js
@@ -29,11 +29,18 @@ export default function HealthTimeline({ providerId, hours = 24 }) {
     };
 
     fetchTimeline();
-    const interval = setInterval(fetchTimeline, POLL_MS);
+    let interval = setInterval(fetchTimeline, POLL_MS);
 
     const onVisibility = () => {
-      if (document.hidden) clearInterval(interval);
-      else { fetchTimeline(); setInterval(fetchTimeline, POLL_MS); }
+      if (document.hidden) {
+        clearInterval(interval);
+      } else {
+        // H3 FIX: Clear any existing interval before creating a new one to
+        // prevent orphaned intervals that leak on each tab refocus.
+        clearInterval(interval);
+        fetchTimeline();
+        interval = setInterval(fetchTimeline, POLL_MS);
+      }
     };
     document.addEventListener("visibilitychange", onVisibility);
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/QwenCloudProfile.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/QwenCloudProfile.js
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/shared/components";
+
+// QwenCloudProfile — shows the connected QwenCloud user's name, email, avatar.
+export default function QwenCloudProfile({ connectionId }) {
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!connectionId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/providers/${connectionId}/qwencloud-profile`, { cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setProfile(data);
+      } catch { /* non-fatal */ }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [connectionId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-2/50 px-3 py-2">
+        <div className="size-8 animate-pulse rounded-full bg-sidebar" />
+        <div className="flex flex-col gap-1">
+          <div className="h-3 w-32 animate-pulse rounded bg-sidebar" />
+          <div className="h-2 w-48 animate-pulse rounded bg-sidebar" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!profile) return null;
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-2/50 px-3 py-2">
+      {profile.image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={profile.image} alt={profile.name} className="size-9 rounded-full object-cover ring-2 ring-border-subtle" />
+      ) : (
+        <div className="flex size-9 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
+          {profile.name?.charAt(0)?.toUpperCase() || "Q"}
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="truncate text-sm font-medium text-text-main">{profile.name}</p>
+          {profile.email && <span className="truncate text-xs text-text-muted">{profile.email}</span>}
+        </div>
+        <div className="mt-0.5 flex items-center gap-1.5">
+          {profile.channelId && <Badge variant="info" size="sm">Region: {profile.channelId}</Badge>}
+          {profile.uid && <span className="text-[11px] text-text-muted">UID: {profile.uid}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/ThinkingLevelPicker.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ThinkingLevelPicker.js
@@ -45,9 +45,9 @@ export default function ThinkingLevelPicker({ caps, selectedLevel, onSelect }) {
   const options = ALL_LEVELS.filter((opt) => {
     if (opt.value === "auto") return true;
     if (opt.value === "none") return caps?.thinkingCanDisable !== false;
-    // For budget-based levels, respect thinkingRange if set (clamp).
-    // Most models support all levels; the range is a soft clamp applied
-    // downstream in applyThinking, so we show all options here.
+    // "max" reasoning_effort is only supported by specific models (e.g. gpt-5.6-sol).
+    // Other models reject it — hide from picker unless thinkingMaxEffort is set.
+    if (opt.value === "max") return caps?.thinkingMaxEffort === true;
     return true;
   });
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -24,6 +24,7 @@ import ZenmuxPlanSelector from "./ZenmuxPlanSelector";
 import HealthTimeline from "./HealthTimeline";
 import FreeBuffProfile from "./FreeBuffProfile";
 import V0Profile from "./V0Profile";
+import QwenCloudProfile from "./QwenCloudProfile";
 import { useNewBadge } from "@/shared/hooks/useNewBadge";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
@@ -1286,6 +1287,17 @@ export default function ProviderDetailPage() {
                   {providerInfo.notice?.apiKeyUrl ? "Get API Key" : "Sign up / Learn more"}
                 </a>
               )}
+              {providerId === "moonshot" && (
+                <a
+                  href="https://www.kimi.com/activities/viral-referral/share?scenario=invite&from=share_poster&invitation_code=BPGXZR"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-full bg-primary/12 px-3 py-1 text-xs font-semibold text-primary ring-1 ring-primary/20 hover:bg-primary/20 transition-colors"
+                >
+                  <span className="material-symbols-outlined text-sm">celebration</span>
+                  Get KIMI K3 For Free
+                </a>
+              )}
             </div>
             <p className="text-text-muted">
               {connections.length} connection{connections.length === 1 ? "" : "s"}
@@ -1393,6 +1405,9 @@ export default function ProviderDetailPage() {
               )}
               {providerId === "v0-vercel-web" && connections.length > 0 && (
                 <V0Profile connectionId={connections[0].id} />
+              )}
+              {providerId === "qwencloud" && connections.length > 0 && (
+                <QwenCloudProfile connectionId={connections[0].id} />
               )}
             </div>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCardV2.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCardV2.js
@@ -14,7 +14,7 @@ const SVG_ICON_IDS = new Set([
   "chatgpt-web", "doubao-web", "gemini-web", "copilot-web", "muse-spark-web",
   "duckduckgo-web", "venice-web", "t3-web", "lmarena", "veoaifree-web",
   "claude-web", "pollinations", "poe-web", "v0-vercel-web", "qwen-web",
-  "kimi-web", "huggingchat", "api-airforce", "openvecta", "freebuff-web", "zenmux-free",
+  "kimi-web", "huggingchat", "api-airforce", "openvecta", "freebuff-web", "zenmux-free", "perplexity-agent", "featherless", "moonshot", "qwencloud",
 ]);
 
 /**

--- a/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
+++ b/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
@@ -31,6 +31,9 @@ export default function TokenSaverClient() {
   const [semanticCacheEnabled, setSemanticCacheEnabled] = useState(false);
   const [semanticCacheThreshold, setSemanticCacheThreshold] = useState(0.85);
   const [cacheStats, setCacheStats] = useState(null);
+  const [pxpipeEnabled, setPxpipeEnabled] = useState(false);
+  const [pxpipeStatus, setPxpipeStatus] = useState({ installed: false, loaded: false, version: null, loading: true });
+  const [pxpipeInstalling, setPxpipeInstalling] = useState(false);
   const [locale, setLocale] = useState("en");
 
   const { copied, copy } = useCopyToClipboard();
@@ -155,6 +158,34 @@ export default function TokenSaverClient() {
     patchSetting({ ponytailLevel: level });
   };
 
+  const handlePxpipeToggle = (value) => {
+    setPxpipeEnabled(value);
+    patchSetting({ pxpipeEnabled: value });
+  };
+
+  const refreshPxpipeStatus = async () => {
+    setPxpipeStatus((s) => ({ ...s, loading: true }));
+    try {
+      const res = await fetch("/api/pxpipe/status", { headers: { "Cache-Control": "no-store" } });
+      const data = await res.json();
+      setPxpipeStatus({ ...data, loading: false });
+    } catch {
+      setPxpipeStatus({ installed: false, loaded: false, version: null, loading: false });
+    }
+  };
+
+  const handlePxpipeInstall = async () => {
+    setPxpipeInstalling(true);
+    try {
+      const res = await fetch("/api/pxpipe/install", { method: "POST" });
+      const data = await res.json();
+      await refreshPxpipeStatus();
+    } catch {
+      // non-fatal
+    }
+    setPxpipeInstalling(false);
+  };
+
   const handleSemanticCacheToggle = (value) => {
     setSemanticCacheEnabled(value);
     patchSetting({ semanticCacheEnabled: value });
@@ -184,7 +215,9 @@ export default function TokenSaverClient() {
           setPonytailLevel(data.ponytailLevel || "full");
           setSemanticCacheEnabled(!!data.semanticCacheEnabled);
           setSemanticCacheThreshold(typeof data.semanticCacheThreshold === "number" ? data.semanticCacheThreshold : 0.85);
+          setPxpipeEnabled(!!data.pxpipeEnabled);
           refreshHeadroomStatus();
+          refreshPxpipeStatus();
         }
       } catch {}
     };
@@ -455,6 +488,64 @@ export default function TokenSaverClient() {
                 Clear Cache
               </Button>
             </div>
+          </div>
+        )}
+      </Card>
+
+      {/* Pxpipe — Multimodal Prompt Compression */}
+      <Card>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="material-symbols-outlined text-text-muted">image_compressor</span>
+            <div>
+              <p className="text-sm font-medium text-text-main">
+                Pxpipe (Image Compression)
+              </p>
+              <p className="text-xs text-text-muted mt-0.5">
+                Render dense Claude-format contexts as PNG images before dispatch. Saves ~35-60% input tokens on large payloads.
+              </p>
+            </div>
+          </div>
+          <Toggle
+            checked={pxpipeEnabled}
+            onChange={() => handlePxpipeToggle(!pxpipeEnabled)}
+          />
+        </div>
+        {pxpipeEnabled && (
+          <div className="mt-4 flex flex-col gap-3 border-t border-border-subtle pt-3">
+            <div className="flex items-center gap-2 text-xs">
+              <span className={`material-symbols-outlined text-[14px] ${pxpipeStatus.installed ? "text-success" : "text-warning"}`}>
+                {pxpipeStatus.installed ? "check_circle" : "error"}
+              </span>
+              <span className="text-text-muted">
+                Package: {pxpipeStatus.installed ? `v${pxpipeStatus.version || "?"} installed` : "not installed"}
+              </span>
+              {pxpipeStatus.loaded && (
+                <Badge variant="success" size="sm" dot>Loaded</Badge>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                icon={pxpipeInstalling ? "progress_activity" : "download"}
+                onClick={handlePxpipeInstall}
+                disabled={pxpipeInstalling}
+              >
+                {pxpipeInstalling ? "Installing..." : pxpipeStatus.installed ? "Reinstall / Upgrade" : "Install Package"}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                icon="refresh"
+                onClick={refreshPxpipeStatus}
+              >
+                Refresh Status
+              </Button>
+            </div>
+            <p className="text-[11px] text-text-muted">
+              Only activates for Claude-format requests with text content above threshold. Fail-open — never blocks requests.
+            </p>
           </div>
         )}
       </Card>

--- a/src/app/api/providers/[id]/qwencloud-profile/route.js
+++ b/src/app/api/providers/[id]/qwencloud-profile/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { getProviderConnectionById } from "@/lib/localDb";
+
+// GET /api/providers/[id]/qwencloud-profile
+// Fetches QwenCloud user profile (email, avatar, uid) via account/info.json.
+export async function GET(_request, { params }) {
+  try {
+    const { id } = await params;
+    const connection = await getProviderConnectionById(id);
+    if (!connection) return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+
+    let cookie = (connection.apiKey || "").replace(/^Cookie:\s*/i, "").trim();
+    if (cookie.startsWith("cookie=")) cookie = cookie.slice(7).trim();
+    // Strip bx-ua/bx-umidtoken
+    cookie = cookie.replace(/bx-ua=[^\s;]+;?\s*/g, "").replace(/bx-umidtoken=[^\s;]+;?\s*/g, "").trim();
+
+    const res = await fetch("https://home.qwencloud.com/api/account/info.json", {
+      method: "GET",
+      headers: {
+        Cookie: cookie,
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
+      },
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      return NextResponse.json({ error: "Session expired" }, { status: 401 });
+    }
+    if (!res.ok) {
+      return NextResponse.json({ error: `QwenCloud returned ${res.status}` }, { status: res.status });
+    }
+
+    const json = await res.json();
+    const d = json?.data;
+    if (!d) return NextResponse.json({ error: "No user data" }, { status: 401 });
+
+    return NextResponse.json({
+      name: d.aliyunId?.split("@")[0] || `User ${d.currentId}`,
+      email: d.aliyunId || "",
+      image: d.headUrl || "",
+      uid: d.currentId || "",
+      channelId: d.channelId || "",
+    });
+  } catch (err) {
+    return NextResponse.json({ error: err?.message || "Failed to fetch profile" }, { status: 500 });
+  }
+}

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -1084,6 +1084,37 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         }, effectiveProxy);
         return { valid: res.ok, error: res.ok ? null : "Pollinations gateway is unreachable" };
       }
+      case "qwencloud": {
+        let cookie = connection.apiKey.replace(/^Cookie:\s*/i, "").trim();
+        if (cookie.startsWith("cookie=")) cookie = cookie.slice(7).trim();
+        const res = await fetchWithConnectionProxy("https://home.qwencloud.com/tool/user/info.json", {
+          method: "GET",
+          headers: { Cookie: cookie, "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36" },
+        }, effectiveProxy);
+        if (res.status === 401 || res.status === 403) return { valid: false, error: "Invalid or expired qwencloud.com session cookie" };
+        if (!res.ok) return { valid: false, error: `QwenCloud returned ${res.status}` };
+        const data = await res.json().catch(() => null);
+        const valid = !!(data?.data?.secToken);
+        return { valid, error: valid ? null : "Session accepted but no secToken — cookie may be expired" };
+      }
+      case "moonshot": {
+        const res = await fetchWithConnectionProxy("https://api.moonshot.ai/v1/models", {
+          headers: { Authorization: `Bearer ${connection.apiKey}` },
+        }, effectiveProxy);
+        return { valid: res.ok, error: res.ok ? null : "Invalid Moonshot API key" };
+      }
+      case "featherless": {
+        const res = await fetchWithConnectionProxy("https://api.featherless.ai/v1/models?per_page=1", {
+          headers: { Authorization: `Bearer ${connection.apiKey}` },
+        }, effectiveProxy);
+        return { valid: res.ok, error: res.ok ? null : "Invalid Featherless API key" };
+      }
+      case "perplexity-agent": {
+        const res = await fetchWithConnectionProxy("https://api.perplexity.ai/v1/models", {
+          headers: { Authorization: `Bearer ${connection.apiKey}` },
+        }, effectiveProxy);
+        return { valid: res.ok, error: res.ok ? null : "Invalid Perplexity API key" };
+      }
       case "openvecta": {
         // OpenAI-compatible gateway — validate via /v1/models with Bearer.
         const res = await fetchWithConnectionProxy("https://openvecta.com/v1/models", {

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -1070,6 +1070,67 @@ export async function POST(request) {
           }
           break;
         }
+        case "qwencloud": {
+          let cookie = apiKey.replace(/^Cookie:\s*/i, "").trim();
+          if (cookie.startsWith("cookie=")) cookie = cookie.slice(7).trim();
+          // Strip bx-ua/bx-umidtoken from credential for validation
+          cookie = cookie.replace(/bx-ua=[^\s;]+;?\s*/g, "").replace(/bx-umidtoken=[^\s;]+;?\s*/g, "").trim();
+          try {
+            const res = await fetch("https://home.qwencloud.com/tool/user/info.json", {
+              method: "GET",
+              headers: { Cookie: cookie, "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36" },
+            });
+            if (res.status === 401 || res.status === 403) { isValid = false; error = "Invalid or expired qwencloud.com session cookie"; }
+            else if (!res.ok) { isValid = false; error = `QwenCloud returned ${res.status}`; }
+            else {
+              const data = await res.json().catch(() => null);
+              isValid = !!(data?.data?.secToken);
+              if (!isValid) error = "Session accepted but no secToken — cookie may be expired";
+            }
+          } catch (err) {
+            isValid = false; error = err.message || "Failed to validate QwenCloud session";
+          }
+          break;
+        }
+        case "moonshot": {
+          try {
+            const res = await fetch("https://api.moonshot.ai/v1/models", {
+              headers: { Authorization: `Bearer ${apiKey}` },
+            });
+            isValid = res.ok;
+            if (!isValid) error = "Invalid Moonshot API key";
+          } catch (err) {
+            isValid = false;
+            error = err.message || "Failed to validate Moonshot key";
+          }
+          break;
+        }
+        case "featherless": {
+          try {
+            const res = await fetch("https://api.featherless.ai/v1/models?per_page=1", {
+              headers: { Authorization: `Bearer ${apiKey}` },
+            });
+            isValid = res.ok;
+            if (!isValid) error = "Invalid Featherless API key";
+          } catch (err) {
+            isValid = false;
+            error = err.message || "Failed to validate Featherless key";
+          }
+          break;
+        }
+        case "perplexity-agent": {
+          try {
+            const res = await fetch("https://api.perplexity.ai/v1/models", {
+              headers: { Authorization: `Bearer ${apiKey}` },
+            });
+            isValid = res.ok;
+            if (!isValid) error = "Invalid Perplexity API key";
+          } catch (err) {
+            isValid = false;
+            error = err.message || "Failed to validate Perplexity key";
+          }
+          break;
+        }
         case "openvecta": {
           try {
             const res = await fetch("https://openvecta.com/v1/models", {

--- a/src/app/api/pxpipe/install/route.js
+++ b/src/app/api/pxpipe/install/route.js
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { installPxpipe } from "@/lib/pxpipe/manager.js";
+import { unloadPxpipeModule } from "open-sse/rtk/pxpipe.js";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/pxpipe/install — install or upgrade pxpipe-proxy npm package.
+export async function POST() {
+  try {
+    unloadPxpipeModule(); // clear cache so new version loads on next request
+    const result = installPxpipe();
+    if (result.success) {
+      return NextResponse.json({ success: true, version: result.version });
+    }
+    return NextResponse.json({ success: false, error: result.error }, { status: 500 });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/pxpipe/status/route.js
+++ b/src/app/api/pxpipe/status/route.js
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getPxpipeStatus } from "@/lib/pxpipe/manager.js";
+import { isPxpipeLoaded } from "open-sse/rtk/pxpipe.js";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/pxpipe/status — returns install status + module loaded state.
+export async function GET() {
+  try {
+    const status = getPxpipeStatus();
+    return NextResponse.json({ ...status, loaded: isPxpipeLoaded() });
+  } catch (error) {
+    return NextResponse.json({ installed: false, loaded: false, error: error.message }, { status: 500 });
+  }
+}

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -54,6 +54,11 @@ const DEFAULT_SETTINGS = {
   cavemanLevel: "full",
   ponytailEnabled: false,
   ponytailLevel: "full",
+  // Pxpipe — multimodal prompt compression (in-process library)
+  pxpipeEnabled: false,
+  pxpipeAutoInstall: false,
+  pxpipeMinChars: 25000,
+  pxpipeTimeoutMs: 5000,
   // Semantic Cache — Jaccard similarity-based response cache
   semanticCacheEnabled: false,
   semanticCacheThreshold: 0.85,

--- a/src/lib/network/pickProxyPoolId.js
+++ b/src/lib/network/pickProxyPoolId.js
@@ -1,0 +1,38 @@
+// pickProxyPoolId — shared utility for auto-rotating proxy pool selection.
+//
+// Used by auth.js for no-auth providers that want to distribute requests
+// across all active proxy pools instead of pinning to one.
+//
+// Round-robin state is deliberately in-memory (not persisted) — resetting
+// the index on server restart is fairer than resuming from a potentially
+// biased last index. If a pool is deleted, the cycle automatically adjusts.
+
+// Per-provider round-robin cursor. Survives hot-reload via global.
+const RR_CURSORS = (global._proxyRRcursors ??= new Map()); // providerId → number
+
+/**
+ * Pick a proxy pool ID from a list, using the configured strategy.
+ *
+ * @param {string[]} poolIds — active proxy pool IDs (must have ≥1)
+ * @param {string} strategy — "none" | "round-robin" | "random"
+ * @param {string} providerId — used as round-robin cursor key
+ * @returns {string|null} selected pool ID, or null if no pools
+ */
+export function pickProxyPoolId(poolIds, strategy, providerId) {
+  if (!poolIds || poolIds.length === 0) return null;
+  if (poolIds.length === 1) return poolIds[0]; // no rotation needed
+
+  if (strategy === "round-robin") {
+    const idx = RR_CURSORS.get(providerId) || 0;
+    const selected = poolIds[idx % poolIds.length];
+    RR_CURSORS.set(providerId, (idx + 1) % poolIds.length);
+    return selected;
+  }
+
+  if (strategy === "random") {
+    return poolIds[Math.floor(Math.random() * poolIds.length)];
+  }
+
+  // "none" or unknown → first pool
+  return poolIds[0];
+}

--- a/src/lib/pxpipe/manager.js
+++ b/src/lib/pxpipe/manager.js
@@ -1,0 +1,97 @@
+// Managed pxpipe install — handles npm install of pxpipe-proxy into DATA_DIR/pxpipe.
+// Mirrors the Headroom process pattern but for an in-process library, not a subprocess.
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { DATA_DIR } from "@/lib/dataDir.js";
+
+const POMPIPED_DIR = join(DATA_DIR || ".", "pxpipe");
+const POMPIPED_VERSION_FILE = join(POMPIPED_DIR, ".installed-version");
+const POMPIPED_PACKAGE = "pxpipe-proxy";
+
+/**
+ * Get the pxpipe install directory.
+ */
+export function getPxpipeDir() {
+  return POMPIPED_DIR;
+}
+
+/**
+ * Check if pxpipe is installed by looking for the package entry.
+ */
+export function isPxpipeInstalled() {
+  try {
+    const { createRequire } = require("node:module");
+    const req = createRequire(import.meta.url);
+    req.resolve("pxpipe-proxy/transform", { paths: [POMPIPED_DIR] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the installed pxpipe version, or null.
+ */
+export function getPxpipeVersion() {
+  try {
+    return readFileSync(POMPIPED_VERSION_FILE, "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install or upgrade pxpipe-proxy into DATA_DIR/pxpipe.
+ * Creates the directory, runs npm install, writes version file.
+ *
+ * @returns {{ success: boolean, version?: string, error?: string }}
+ */
+export function installPxpipe() {
+  try {
+    if (!existsSync(POMPIPED_DIR)) {
+      mkdirSync(POMPIPED_DIR, { recursive: true });
+    }
+
+    // Write a minimal package.json so npm install works in this dir.
+    const pkgPath = join(POMPIPED_DIR, "package.json");
+    if (!existsSync(pkgPath)) {
+      writeFileSync(pkgPath, JSON.stringify({
+        name: "extremerouter-pxpipe",
+        private: true,
+        type: "module",
+      }, null, 2));
+    }
+
+    // Install the package.
+    execSync(`npm install ${POMPIPED_PACKAGE}@latest --no-save --prefix "${POMPIPED_DIR}"`, {
+      cwd: POMPIPED_DIR,
+      stdio: "pipe",
+      timeout: 60_000,
+    });
+
+    // Read installed version.
+    let version = "unknown";
+    try {
+      const pkgJson = JSON.parse(readFileSync(join(POMPIPED_DIR, "node_modules", POMPIPED_PACKAGE, "package.json"), "utf-8"));
+      version = pkgJson.version || "unknown";
+    } catch {}
+
+    writeFileSync(POMPIPED_VERSION_FILE, version);
+    return { success: true, version };
+  } catch (error) {
+    return { success: false, error: error?.message || String(error) };
+  }
+}
+
+/**
+ * Get comprehensive status for the pxpipe system.
+ */
+export function getPxpipeStatus() {
+  return {
+    installed: isPxpipeInstalled(),
+    version: getPxpipeVersion(),
+    dir: POMPIPED_DIR,
+  };
+}

--- a/src/shared/components/NoAuthProxyCard.js
+++ b/src/shared/components/NoAuthProxyCard.js
@@ -8,9 +8,16 @@ import Badge from "./Badge";
 
 const NONE_PROXY_POOL_VALUE = "__none__";
 
+const ROTATE_OPTIONS = [
+  { value: "none", label: "None (single pool)" },
+  { value: "round-robin", label: "Round Robin — cycle through all pools" },
+  { value: "random", label: "Random — pick a random pool each request" },
+];
+
 export default function NoAuthProxyCard({ providerId }) {
   const [proxyPools, setProxyPools] = useState([]);
   const [proxyPoolId, setProxyPoolId] = useState(NONE_PROXY_POOL_VALUE);
+  const [rotateStrategy, setRotateStrategy] = useState("none");
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
 
@@ -24,21 +31,23 @@ export default function NoAuthProxyCard({ providerId }) {
       setProxyPools(poolData.proxyPools || []);
       const override = (settingsData.providerStrategies || {})[providerId] || {};
       setProxyPoolId(override.proxyPoolId || NONE_PROXY_POOL_VALUE);
+      setRotateStrategy(override.rotateStrategy || "none");
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [providerId]);
 
-  const handleChange = async (newValue) => {
-    setProxyPoolId(newValue);
+  const patchSettings = async (patch) => {
     setSaving(true);
     try {
       const res = await fetch("/api/settings", { cache: "no-store" });
       const data = res.ok ? await res.json() : {};
       const current = data.providerStrategies || {};
       const override = { ...(current[providerId] || {}) };
-      if (newValue === NONE_PROXY_POOL_VALUE) delete override.proxyPoolId;
-      else override.proxyPoolId = newValue;
       const updated = { ...current };
+      Object.assign(override, patch);
+      // Clean up empty values
+      if (!override.proxyPoolId) delete override.proxyPoolId;
+      if (!override.rotateStrategy || override.rotateStrategy === "none") delete override.rotateStrategy;
       if (Object.keys(override).length === 0) delete updated[providerId];
       else updated[providerId] = override;
       await fetch("/api/settings", {
@@ -49,11 +58,24 @@ export default function NoAuthProxyCard({ providerId }) {
       setSavedFlash(true);
       setTimeout(() => setSavedFlash(false), 1500);
     } catch (e) {
-      console.log("Save proxyPoolId error:", e);
+      console.log("Save settings error:", e);
     } finally {
       setSaving(false);
     }
   };
+
+  const handlePoolChange = (newValue) => {
+    setProxyPoolId(newValue);
+    patchSettings({ proxyPoolId: newValue === NONE_PROXY_POOL_VALUE ? "" : newValue });
+  };
+
+  const handleRotateChange = (newValue) => {
+    setRotateStrategy(newValue);
+    patchSettings({ rotateStrategy: newValue });
+  };
+
+  const isRotating = rotateStrategy !== "none";
+  const canRotate = proxyPools.length >= 2;
 
   return (
     <Card>
@@ -67,16 +89,35 @@ export default function NoAuthProxyCard({ providerId }) {
         </div>
         {savedFlash && <Badge variant="success" size="sm">Saved</Badge>}
       </div>
-      <Select
-        label="Proxy Pool"
-        value={proxyPoolId}
-        onChange={(e) => handleChange(e.target.value)}
-        disabled={saving}
-        options={[
-          { value: NONE_PROXY_POOL_VALUE, label: "None (direct)" },
-          ...proxyPools.map((pool) => ({ value: pool.id, label: pool.name })),
-        ]}
-      />
+      <div className="flex flex-col gap-4">
+        {/* Rotation Strategy */}
+        <Select
+          label="Rotation Strategy"
+          value={rotateStrategy}
+          onChange={(e) => handleRotateChange(e.target.value)}
+          disabled={saving}
+          hint={isRotating
+            ? (canRotate ? `Rotating across ${proxyPools.length} active pools` : "Need ≥2 active pools for rotation")
+            : "Distribute requests across all active proxy pools"}
+          options={ROTATE_OPTIONS.map((opt) => ({
+            ...opt,
+            // Disable round-robin/random if fewer than 2 pools
+            ...((opt.value !== "none" && !canRotate) ? { label: `${opt.label} (need ≥2 pools)` } : {}),
+          }))}
+        />
+        {/* Proxy Pool — disabled when rotation is active */}
+        <Select
+          label="Proxy Pool"
+          value={proxyPoolId}
+          onChange={(e) => handlePoolChange(e.target.value)}
+          disabled={saving || isRotating}
+          hint={isRotating ? "Disabled — rotation auto-selects from all pools" : undefined}
+          options={[
+            { value: NONE_PROXY_POOL_VALUE, label: "None (direct)" },
+            ...proxyPools.map((pool) => ({ value: pool.id, label: pool.name })),
+          ]}
+        />
+      </div>
     </Card>
   );
 }

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -8,10 +8,13 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
+import { readBodyWithLimit } from "../utils/bodyLimiter.js";
+import { checkRateLimit, evictExpiredBuckets } from "../utils/rateLimiter.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
+import { getPxpipeDir } from "@/lib/pxpipe/manager.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat, handleSwarmChat } from "open-sse/services/combo.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
@@ -20,7 +23,7 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
-import { recordBreakerSuccess, recordBreakerFailure, isRetryableFailure } from "open-sse/services/circuitBreaker.js";
+import { recordBreakerSuccess, recordBreakerFailure, isRetryableFailure, releaseBreakerProbe } from "open-sse/services/circuitBreaker.js";
 import { recordHealthSample } from "open-sse/services/healthMonitor.js";
 import { getApiKeyByKey } from "@/lib/localDb";
 
@@ -32,8 +35,13 @@ import { getApiKeyByKey } from "@/lib/localDb";
 export async function handleChat(request, clientRawRequest = null) {
   let body;
   try {
-    body = await request.json();
-  } catch {
+    // C2 FIX: Limit body size to prevent OOM/DoS (10 MB max for chat)
+    const bodyText = await readBodyWithLimit(request, 10 * 1024 * 1024);
+    body = JSON.parse(bodyText);
+  } catch (e) {
+    if (e.message?.includes("too large")) {
+      return errorResponse(HTTP_STATUS.BAD_REQUEST, e.message);
+    }
     log.warn("CHAT", "Invalid JSON body");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
   }
@@ -62,6 +70,32 @@ export async function handleChat(request, clientRawRequest = null) {
   // Log API key (masked)
   const authHeader = request.headers.get("Authorization");
   const apiKey = extractApiKey(request);
+
+  // C3 FIX: Rate limiting — keyed on API key or client IP
+  const rateLimitKey = apiKey || clientRawRequest?.headers?.["x-9r-real-ip"] || "anonymous";
+  const rateLimit = checkRateLimit(rateLimitKey);
+  evictExpiredBuckets(); // lazy eviction
+  if (!rateLimit.allowed) {
+    log.warn("RATE", `Rate limited: ${rateLimitKey.slice(0, 12)}... retry in ${Math.ceil(rateLimit.retryAfterMs / 1000)}s`);
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: `Rate limit exceeded. Try again in ${Math.ceil(rateLimit.retryAfterMs / 1000)} seconds.`,
+          type: "rate_limit_error",
+          code: "rate_limited",
+        },
+      }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": String(Math.ceil(rateLimit.retryAfterMs / 1000)),
+          "X-RateLimit-Remaining": String(rateLimit.remaining),
+        },
+      },
+    );
+  }
+
   if (authHeader && apiKey) {
     const masked = log.maskKey(apiKey);
     log.debug("AUTH", `API Key: ${masked}`);
@@ -90,7 +124,10 @@ export async function handleChat(request, clientRawRequest = null) {
 
   // Per-Key Model Access Control: if the resolved API key has an allowedModels
   // list, reject requests to models not in the list.
-  if (settings.requireApiKey && apiKey) {
+  // H2 FIX: Enforce ACL whenever an API key is present, regardless of
+  // requireApiKey setting. Previously this was gated on requireApiKey=true,
+  // meaning local mode (requireApiKey=false) had no model ACL at all.
+  if (apiKey) {
     try {
       const keyObj = await getApiKeyByKey(apiKey);
       if (keyObj && Array.isArray(keyObj.allowedModels) && keyObj.allowedModels.length > 0) {
@@ -318,6 +355,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Use shared chatCore
     const chatSettings = await getSettings();
     const providerThinking = (chatSettings.providerThinking || {})[provider] || null;
+    const pxpipeDir = getPxpipeDir();
     const attemptStart = Date.now();
     const result = await handleChatCore({
       body: { ...body, model: `${provider}/${model}` },
@@ -337,6 +375,10 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       cavemanLevel: chatSettings.cavemanLevel || "full",
       ponytailEnabled: !!chatSettings.ponytailEnabled,
       ponytailLevel: chatSettings.ponytailLevel || "full",
+      pxpipeEnabled: !!chatSettings.pxpipeEnabled,
+      pxpipeDir: pxpipeDir,
+      pxpipeMinChars: chatSettings.pxpipeMinChars || 25000,
+      pxpipeTimeoutMs: chatSettings.pxpipeTimeoutMs || 5000,
       semanticCacheEnabled: !!chatSettings.semanticCacheEnabled,
       semanticCacheThreshold: typeof chatSettings.semanticCacheThreshold === "number" ? chatSettings.semanticCacheThreshold : 0.85,
       providerThinking,
@@ -352,6 +394,11 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       onRequestSuccess: async () => {
         await clearAccountError(credentials.connectionId, credentials, model);
       }
+    }).catch(err => {
+      // Probe-slot leak fix: if handleChatCore throws (abort, network error),
+      // release the claimed half-open probe slot so the breaker doesn't get stuck.
+      releaseBreakerProbe(provider);
+      throw err;
     });
 
     if (result.success) {

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -8,6 +8,8 @@ import {
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
 import { handleEmbeddingsCore } from "open-sse/handlers/embeddingsCore.js";
+import { readBodyWithLimit } from "../utils/bodyLimiter.js";
+import { checkRateLimit, evictExpiredBuckets } from "../utils/rateLimiter.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import * as log from "../utils/logger.js";
@@ -22,8 +24,14 @@ import { updateProviderCredentials, checkAndRefreshToken } from "../services/tok
 export async function handleEmbeddings(request) {
   let body;
   try {
-    body = await request.json();
-  } catch {
+    // C2 FIX: Limit body size (4 MB for embeddings — typically smaller than chat)
+    const bodyText = await readBodyWithLimit(request, 4 * 1024 * 1024);
+    body = JSON.parse(bodyText);
+  } catch (e) {
+    if (e.message?.includes("too large")) {
+      return errorResponse(HTTP_STATUS.BAD_REQUEST, e.message);
+    }
+    log.warn("EMBEDDINGS", "Invalid JSON body");
     log.warn("EMBEDDINGS", "Invalid JSON body");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
   }
@@ -35,6 +43,14 @@ export async function handleEmbeddings(request) {
 
   // Log API key (masked)
   const apiKey = extractApiKey(request);
+
+  // Rate limiting (same pattern as chat.js)
+  const rlKey = apiKey || request.headers.get("x-9r-real-ip") || "anonymous";
+  const rl = checkRateLimit(rlKey);
+  evictExpiredBuckets();
+  if (!rl.allowed) {
+    return new Response(JSON.stringify({ error: { message: `Rate limit exceeded. Try again in ${Math.ceil(rl.retryAfterMs / 1000)} seconds.`, type: "rate_limit_error", code: "rate_limited" } }), { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } });
+  }
   if (apiKey) {
     log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
   } else {

--- a/src/sse/handlers/fetch.js
+++ b/src/sse/handlers/fetch.js
@@ -8,6 +8,8 @@ import {
 import { getSettings, getCombos } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
 import { handleFetchCore } from "open-sse/handlers/fetch/index.js";
+import { readBodyWithLimit } from "../utils/bodyLimiter.js";
+import { checkRateLimit, evictExpiredBuckets } from "../utils/rateLimiter.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import * as log from "../utils/logger.js";
@@ -24,8 +26,14 @@ import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
 export async function handleFetch(request) {
   let body;
   try {
-    body = await request.json();
-  } catch {
+    // C2 FIX: Limit body size (2 MB for fetch — URLs + small payloads)
+    const bodyText = await readBodyWithLimit(request, 2 * 1024 * 1024);
+    body = JSON.parse(bodyText);
+  } catch (e) {
+    if (e.message?.includes("too large")) {
+      return errorResponse(HTTP_STATUS.BAD_REQUEST, e.message);
+    }
+    log.warn("FETCH", "Invalid JSON body");
     log.warn("FETCH", "Invalid JSON body");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
   }
@@ -41,6 +49,14 @@ export async function handleFetch(request) {
 
   // Log API key (masked)
   const apiKey = extractApiKey(request);
+
+  // Rate limiting
+  const rlKey = apiKey || request.headers.get("x-9r-real-ip") || "anonymous";
+  const rl = checkRateLimit(rlKey);
+  evictExpiredBuckets();
+  if (!rl.allowed) {
+    return new Response(JSON.stringify({ error: { message: `Rate limit exceeded. Try again in ${Math.ceil(rl.retryAfterMs / 1000)} seconds.`, type: "rate_limit_error", code: "rate_limited" } }), { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } });
+  }
   if (apiKey) {
     log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
   } else {

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,4 +1,4 @@
-import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings } from "@/lib/localDb";
+import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
@@ -37,7 +37,23 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
     if (FREE_PROVIDERS[providerId]?.noAuth) {
       const settings = await getSettings();
       const override = (settings.providerStrategies || {})[providerId] || {};
-      const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: override.proxyPoolId || "" });
+      const rotateStrategy = override.rotateStrategy || "none";
+
+      let poolId = override.proxyPoolId || "";
+
+      // Auto-rotate: if rotation strategy is set, pick from all active pools
+      if (rotateStrategy !== "none" && rotateStrategy) {
+        try {
+          const allPools = await getProxyPools({ isActive: true });
+          const poolIds = allPools.map((p) => p.id).filter(Boolean);
+          if (poolIds.length >= 2) {
+            const { pickProxyPoolId } = await import("@/lib/network/pickProxyPoolId.js");
+            poolId = pickProxyPoolId(poolIds, rotateStrategy, providerId) || poolId;
+          }
+        } catch { /* fail-open: fall back to static poolId */ }
+      }
+
+      const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: poolId });
       return {
         id: "noauth",
         connectionName: "Public",

--- a/src/sse/utils/bodyLimiter.js
+++ b/src/sse/utils/bodyLimiter.js
@@ -1,0 +1,47 @@
+// Body size limiter — rejects requests with bodies exceeding the configured max.
+// Prevents OOM/DoS via oversized request bodies before JSON parsing.
+//
+// Usage:
+//   const body = await readBodyWithLimit(request, 10 * 1024 * 1024); // 10 MB
+//   const data = JSON.parse(body);
+
+const DEFAULT_MAX_BODY = 10 * 1024 * 1024; // 10 MB
+
+/**
+ * Read the request body as a string, rejecting if it exceeds maxBytes.
+ * Checks Content-Length header first (fast reject), then streams with a cap.
+ *
+ * @param {Request} request
+ * @param {number} maxBytes - maximum body size in bytes (default: 10 MB)
+ * @returns {Promise<string>} body as string
+ * @throws {Error} if body exceeds limit
+ */
+export async function readBodyWithLimit(request, maxBytes = DEFAULT_MAX_BODY) {
+  // Fast path: check Content-Length header
+  const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+  if (contentLength > maxBytes) {
+    throw new Error(`Request body too large: ${contentLength} bytes exceeds ${maxBytes} byte limit`);
+  }
+
+  // Stream path: read with accumulation + cap
+  const reader = request.body?.getReader();
+  if (!reader) return "";
+
+  const decoder = new TextDecoder();
+  let received = 0;
+  let body = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.length;
+    if (received > maxBytes) {
+      try { reader.cancel(); } catch {}
+      throw new Error(`Request body too large: exceeds ${maxBytes} byte limit`);
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+  body += decoder.decode(); // flush
+
+  return body;
+}

--- a/src/sse/utils/rateLimiter.js
+++ b/src/sse/utils/rateLimiter.js
@@ -1,0 +1,81 @@
+// Rate limiter — sliding window per-key/IP limiter for the LLM API.
+//
+// Prevents DoS amplification: without rate limiting, a single client can exhaust
+// provider quotas, trigger OAuth rate limits, and trip circuit breakers for all
+// legitimate users.
+//
+// Design:
+//   - Token bucket with configurable burst + refill rate
+//   - Keyed on API key (preferred) or client IP (fallback)
+//   - In-memory Map (survives hot-reload via global)
+//   - Lazy eviction of expired buckets (no background timer)
+//   - Fail-open: if the limiter crashes, the request proceeds
+//
+// Limits (configurable via env):
+//   DEFAULT_RPM = 60 requests/minute per key (generous for coding assistants)
+//   DEFAULT_BURST = 10 (max burst before refill kicks in)
+
+const DEFAULT_RPM = parseInt(process.env.EXTREMEROUTER_RATE_LIMIT_RPM || "60", 10);
+const DEFAULT_BURST = parseInt(process.env.EXTREMEROUTER_RATE_LIMIT_BURST || "10", 10);
+const WINDOW_MS = 60_000; // 1 minute
+const EVICT_MS = 5 * 60_000; // evict buckets unused for 5 min
+
+const BUCKETS = (global._rateLimitBuckets ??= new Map());
+
+/**
+ * Check if a request should be rate-limited.
+ * Returns { allowed: boolean, retryAfterMs: number, remaining: number }
+ *
+ * @param {string} key - API key or client IP
+ * @param {number} rpm - max requests per minute (default: 60)
+ * @param {number} burst - max burst (default: 10)
+ */
+export function checkRateLimit(key, rpm = DEFAULT_RPM, burst = DEFAULT_BURST) {
+  if (!key) return { allowed: true, retryAfterMs: 0, remaining: burst };
+
+  const now = Date.now();
+  const refillRate = rpm / (WINDOW_MS / 1000); // tokens per second
+
+  let bucket = BUCKETS.get(key);
+  if (!bucket || now - bucket.lastEvicted > EVICT_MS) {
+    bucket = { tokens: burst, lastRefill: now, lastEvicted: now };
+    BUCKETS.set(key, bucket);
+  }
+
+  // Refill tokens based on elapsed time
+  const elapsed = (now - bucket.lastRefill) / 1000;
+  bucket.tokens = Math.min(burst, bucket.tokens + elapsed * refillRate);
+  bucket.lastRefill = now;
+  bucket.lastEvicted = now;
+
+  if (bucket.tokens >= 1) {
+    bucket.tokens -= 1;
+    return { allowed: true, retryAfterMs: 0, remaining: Math.floor(bucket.tokens) };
+  }
+
+  // Rate limited — calculate retry-after
+  const retryAfterMs = Math.ceil((1 - bucket.tokens) / refillRate * 1000);
+  return { allowed: false, retryAfterMs: Math.max(retryAfterMs, 1000), remaining: 0 };
+}
+
+/**
+ * Evict expired buckets (call periodically or on each check).
+ */
+export function evictExpiredBuckets() {
+  const now = Date.now();
+  for (const [key, bucket] of BUCKETS) {
+    if (now - bucket.lastEvicted > EVICT_MS) {
+      BUCKETS.delete(key);
+    }
+  }
+}
+
+/**
+ * Get rate limiter stats for dashboards.
+ */
+export function getRateLimiterStats() {
+  return {
+    trackedKeys: BUCKETS.size,
+    config: { rpm: DEFAULT_RPM, burst: DEFAULT_BURST, windowMs: WINDOW_MS },
+  };
+}

--- a/tests/unit/pxpipe.test.js
+++ b/tests/unit/pxpipe.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  compressWithPxpipe,
+  formatPxpipeLog,
+  formatPxpipeSizeLog,
+  isPxpipePhantomSavings,
+  isPxpipeLoaded,
+  unloadPxpipeModule,
+} from "../../open-sse/rtk/pxpipe.js";
+
+describe("pxpipe — compressWithPxpipe gates", () => {
+  it("returns null when disabled", async () => {
+    const result = await compressWithPxpipe({ messages: [] }, { enabled: false });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when body has no messages", async () => {
+    const result = await compressWithPxpipe({}, { enabled: true });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when messages is not an array", async () => {
+    const result = await compressWithPxpipe({ messages: "string" }, { enabled: true });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when body is below minChars threshold", async () => {
+    const body = { messages: [{ role: "user", content: "short" }] };
+    const result = await compressWithPxpipe(body, { enabled: true, minChars: 1000 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when pxpipe module is not installed (no dir)", async () => {
+    const longText = "x".repeat(30000);
+    const body = { messages: [{ role: "user", content: longText }] };
+    const result = await compressWithPxpipe(body, { enabled: true, minChars: 25000, pxpipeDir: null });
+    expect(result).toBeNull();
+  });
+
+  it("sets diagnostics reason on each skip path", async () => {
+    const diag = {};
+    await compressWithPxpipe({ messages: [] }, { enabled: false, diagnostics: diag });
+    expect(diag.reason).toBe("disabled");
+
+    const diag2 = {};
+    await compressWithPxpipe({ messages: [{ role: "user", content: "hi" }] }, { enabled: true, minChars: 1000, diagnostics: diag2 });
+    expect(diag2.reason).toMatch(/below threshold/);
+  });
+});
+
+describe("pxpipe — formatPxpipeLog", () => {
+  it("returns null when no stats", () => {
+    expect(formatPxpipeLog(null)).toBeNull();
+  });
+
+  it("returns null when no tokens saved", () => {
+    expect(formatPxpipeLog({ tokensSaved: 0 })).toBeNull();
+  });
+
+  it("formats log line with savings", () => {
+    const line = formatPxpipeLog({ tokensSaved: 5000, tokensBefore: 10000, tokensAfter: 5000, imageCount: 3 });
+    expect(line).toContain("5,000 tokens");
+    expect(line).toContain("10,000");
+    expect(line).toContain("3 images");
+  });
+});
+
+describe("pxpipe — formatPxpipeSizeLog", () => {
+  it("returns null when no diagnostics", () => {
+    expect(formatPxpipeSizeLog(null)).toBeNull();
+  });
+
+  it("formats percentage", () => {
+    const line = formatPxpipeSizeLog({ before: 10000, after: 6000 });
+    expect(line).toContain("10,000");
+    expect(line).toContain("6,000");
+    expect(line).toContain("-40%");
+  });
+});
+
+describe("pxpipe — isPxpipePhantomSavings", () => {
+  it("returns false when no stats", () => {
+    expect(isPxpipePhantomSavings(null, null)).toBe(false);
+  });
+
+  it("returns false when tokensSaved is 0", () => {
+    expect(isPxpipePhantomSavings({ tokensSaved: 0 }, { before: 100, after: 99 })).toBe(false);
+  });
+
+  it("returns true when shrink ratio is below 5%", () => {
+    expect(isPxpipePhantomSavings(
+      { tokensSaved: 100 },
+      { before: 10000, after: 9900 }, // 1% shrink, but claims 100 saved
+    )).toBe(true);
+  });
+
+  it("returns false when shrink ratio is above 5%", () => {
+    expect(isPxpipePhantomSavings(
+      { tokensSaved: 5000 },
+      { before: 10000, after: 4000 }, // 60% shrink
+    )).toBe(false);
+  });
+});
+
+describe("pxpipe — module lifecycle", () => {
+  it("isPxpipeLoaded returns false when not loaded", () => {
+    unloadPxpipeModule();
+    expect(isPxpipeLoaded()).toBe(false);
+  });
+});


### PR DESCRIPTION
…ipe, security audit fixes

New Features:
- Perplexity Agent provider — multi-model routing via Responses API (33+ models)
- Featherless provider — 46,000+ HuggingFace models with live model discovery
- Moonshot AI provider — kimi-k3 with reasoning_effort max support + free referral button
- QwenCloud cookie provider — multi-step auth (cookie → secToken → accessToken → SSE chat) + profile display
- Pxpipe — 5th token saver, multimodal prompt compression via in-process pxpipe-proxy library
- Auto-rotate proxy strategy for no-auth providers (round-robin / random across all active pools)
- gpt-5.6-sol max thinking level support (thinkingMaxEffort capability flag)
- FreeBuff cookie provider — profile display (avatar, name, email, session expiry) + auto-refresh cookies
- v0.app profile + credit balance display
- Combos redesign — 3 tabs (Overview/Combos/Templates), KPI row, search/filter, expandable cards
- Combo modal redesign — drag-reorder, strategy tips, model count badge

Fixed:
- Security — SSRF guards on proxy/relay URLs + prefetchRemoteImages
- Security — body size limits (10MB chat / 4MB embeddings / 2MB fetch)
- Security — rate limiting per API key/IP across all 3 handlers (chat, embeddings, fetch)
- Security — semantic cache cross-user leak (cache key now includes API key identity)
- Security — circuit breaker half-open probe cap now atomically incremented + slot leak on abort
- Security — auth + model ACL enforced regardless of requireApiKey setting
- HealthTimeline orphaned setInterval leak on tab refocus
- Alerts page stale closure + debounce (useRef + 500ms timer + unmount cleanup)
- Combos delete stale closure (functional state update)
- v0.app executor — 3 critical + 4 medium audit fixes (AbortSignal, per-path text tracking, content-type check)
- Meta AI AttachmentInput GraphQL schema change (omit attachments field)
- MITM stale-lock recovery (validate PID, auto-delete orphan lock files)
- Headroom Kiro conversationState compression path added
- Gemini-CLI thinking budget floor (min 1024) + validated toolConfig for tools
- RTK/find Windows backslash path detection + drive-letter support in autodetect
- Codex capacity/rate_limit SSE patterns added to overloaded detector
- Antigravity fingerprint aligned with IDE Desktop 2.1.1
- Pricing: added claude-opus-4.7/4.8, claude-sonnet-5, claude-fable-5, gpt-5.4/5.5/5.6 variants
- GitHub Copilot account identity labeling via /user fetch
- Provider audit: api-airforce validate, mimo-free/devin/vertex test probes, o1/o3/o4 + claude pattern tightening
- CHANGELOG.md updated with v0.6.0–v0.7.0 entries