### PR TITLE
feat(v0.7.5): Combo engine overhaul (28 fixes), Cline/ClinePass quota…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# v0.7.5 (2026-07-22)
+
+## Features
+- **Cline + ClinePass Quota Tracker**: both providers now report plan usage limits (5-hour / weekly / monthly) as percentUsed in the Quota Tracker dashboard. Shared `getClineUsage` handler with OAuth/API-key auth fallback.
+- **Breaker-Aware Combo Pre-Filter**: combos now proactively skip models whose provider circuit breaker is OPEN before attempting them — saving a wasted credential-selection round-trip per broken model. New read-only `isBreakerBlocking()` check (does not consume the single HALF_OPEN probe slot) + `filterBreakerOpenModels()` helper. Falls back to the original model list if ALL are blocked (probe window may open during attempt).
+- **Providers Page Redesign (list)**: full redesign — 5 collapsible sections replaced with a unified flat grid + filter chips (All / Connected / Errors / OAuth / API Key / Free / Cookie / Custom) + sort dropdown. New rich tiles (ProviderTile) with larger icons, connection counts, status badges, and an action bar (test + settings + toggle). KPI row (ProviderKpis) with interactive Errors tile. Toolbar (ProviderToolbar) with live count badges.
+- **Provider Detail Page Redesign**: God Component (1831 lines) split into 4 extracted components: `ProviderDetailHeader` (branded header), `ConnectionsCard` (toolbar + rows + bulk proxy modal), `ModelsCard` (toolbar + grid), `CollapsibleSection` (reusable wrapper). page.js reduced to a lean orchestrator (~960 lines). Visual polish: branded header with category summary, collapsible sections (Health default-collapsed), responsive model grid (grid-cols-3), progress-bar-style one-by-one test summary, compact pill toolbars.
+
+## Fixes — Combo Engine (28 bug fixes across 4 audit rounds)
+- **C1 Critical — `body_global` race condition** (swarm.js): removed module-level mutable state; `body` threaded explicitly to all stage runners. Concurrent swarm requests no longer clobber each other's prompt (cross-request leak).
+- **C2 Critical — `releaseBreakerProbe` ReferenceError** (circuitBreaker.js): `monitors`→`breakers` — half-open probe slot now releases correctly; breaker no longer stuck open forever.
+- **C1+H2 Critical — orphaned comboStrategies on rename/delete** ([id]/route.js): `patchComboStrategies` now sends partial patches with `{ [key]: null }` delete-signals compatible with the deep-merge in updateSettings.
+- **H1 — Wrong key `comboStickyLimit`** (chat.js): `comboStickyLimit`→`comboStickyRoundRobinLimit`. Round-robin fast-path now respects sticky limit config.
+- **H2 — Lost-update race in `handleSetComboStrategy`** (settingsRepo.js + CombosPageInner.js): backend deep-merges `comboStrategies` at combo-name level; UI sends only the changed entry.
+- **H3 — ComboFormModal stale create state**: reset local draft via `useEffect` watch on `isOpen` transition.
+- **H4 — ComboFormModal closure-models bug**: 3 handlers now use functional updates `setModels(prev => ...)`.
+- **H5 — PUT empty-string name bypass validation**: `if (body.name)` → `if (body.name !== undefined)` + non-empty check.
+- **M1 — Non-array models crash**: `Array.isArray(models)` validation in POST + PUT.
+- **M2 — Case-sensitive strategy compare**: `normalizeStrategy()` helper (trim+lowercase+whitelist).
+- **M3 — Fusion single-survivor stream downgrade**: re-run with stream flag preserved when `body.stream === true`.
+- **M4 — ComboCard null-guard**: `combo.models` normalized to `[]` defensively.
+- **M5 — handleDelete silent failure**: error feedback via `alert()`.
+- **M6 — Cross-strategy breaker pollution**: `skipBreaker` opt for panel calls; fusion/swarm failures no longer trip shared per-provider breaker.
+- **#1 — Fusion single-answer re-run**: return existing panel response instead of re-invoking model.
+- **#3 — `parseStrategy` truncated JSON**: lenient recovery salvages complete subtask objects via regex.
+- **#5 — `workerCount` config ignored**: `workerCount` from UI now honored via `workerCap`.
+- **L1-L9**: `getStrategyDistribution` whitelist, PUT response canonical shape, stale role-field cleanup, ModelSelectModal highlight, `VALID_NAME_REGEX` dedup, ComboFormModal fetch cleanup.
+
+## Fixes — Code Review Feedback
+- **GitHub `/responses` proactive routing** (github.js): `buildUrl()` + `execute()` route `targetFormat:"openai-responses"` models to `/responses` proactively.
+- **xAI unused `U` import** (xai.js): dead code removed.
+- **sanitize-html test** (sanitize-html.test.js): rewritten as idiomatic vitest with `it.each`/`expect` + standalone-script fallback.
+
+## Improvements
+- **Settings deep-merge** (settingsRepo.js): `comboStrategies` merged at combo-name level (not replaced), with `null` as the delete-signal.
+- **Swarm `ALIAS_TO_ID` map** (combo.js): built from REGISTRY for breaker lookups without crossing the open-sse→src layer boundary.
+- **Provider list unified entry array** (providers/page.js): ONE flat array with `category` tags replaces 5 separate section arrays.
+
 # v0.7.4 (2026-07-19)
 
 ## Features

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsalmn/extremerouter",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "ExtremeRouter CLI - AI Gateway control plane",
   "bin": {
     "extremerouter": "./cli.js"

--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -49,6 +49,19 @@ export class GithubExecutor extends BaseExecutor {
     if (getModelTargetFormat("gh", model) === "claude" && this.config.messagesUrl) {
       return this.config.messagesUrl;
     }
+    // GPT/codex models tagged targetFormat:"openai-responses" in the registry
+    // are served exclusively by /responses and 400 on /chat/completions. Route
+    // them proactively so the first request lands on the right endpoint instead
+    // of burning a /chat/completions attempt and escalating reactively.
+    // (See execute() — openai-responses models skip the chat-completions path
+    // entirely via executeWithResponsesEndpoint, which performs the OpenAI →
+    // Responses request translation that /responses requires.)
+    if (
+      getModelTargetFormat("gh", model) === "openai-responses" &&
+      this.config.responsesUrl
+    ) {
+      return this.config.responsesUrl;
+    }
     return this.config.baseUrl;
   }
 
@@ -188,6 +201,21 @@ export class GithubExecutor extends BaseExecutor {
 
   async execute(options) {
     const { model, log } = options;
+
+    // Models the registry explicitly tags targetFormat:"openai-responses"
+    // (gpt-5.5, gpt-5.4, gpt-5.3-codex, …) are served ONLY by /responses and
+    // 400 on /chat/completions with "not accessible via the /chat/completions
+    // endpoint". Dispatch them proactively to the Responses path (which performs
+    // the OpenAI → Responses request translation /responses requires) instead
+    // of wasting a /chat/completions round-trip and escalating reactively.
+    // Still gated by supportsResponsesEndpoint() as defense-in-depth (#1062).
+    if (
+      getModelTargetFormat("gh", model) === "openai-responses" &&
+      this.supportsResponsesEndpoint(model)
+    ) {
+      log?.debug("GITHUB", `Proactive /responses route for ${model} (targetFormat:openai-responses)`);
+      return this.executeWithResponsesEndpoint(options);
+    }
 
     // Only use /responses for models that are explicitly known to need it (e.g. gpt codex models)
     // and that the /responses endpoint actually serves (excludes Gemini/Claude, see #1062).

--- a/open-sse/providers/registry/cline.js
+++ b/open-sse/providers/registry/cline.js
@@ -33,6 +33,11 @@ export default {
         "clineHeaders",
       ],
     },
+    // Quota Tracker — plan usage limits (5h / weekly / monthly) returned as
+    // percentUsed. No absolute token/request counts are exposed.
+    usage: {
+      url: "https://api.cline.bot/api/v1/users/me/plan/usage-limits",
+    },
   },
   // Model IDs follow the documented `{provider}/{model}` format.
   // Source: https://docs.cline.bot/api/models
@@ -57,5 +62,9 @@ export default {
   thinkingConfig: {
     options: ["auto", "on", "off"],
     defaultMode: "auto",
+  },
+  features: {
+    usage: true,
+    usageApikey: true,
   },
 };

--- a/open-sse/providers/registry/clinepass.js
+++ b/open-sse/providers/registry/clinepass.js
@@ -34,6 +34,12 @@ export default {
         "clineHeaders",
       ],
     },
+    // Quota Tracker — plan usage limits (5h / weekly / monthly) returned as
+    // percentUsed. Same host & endpoint as the `cline` provider; both providers
+    // share the getClineUsage handler.
+    usage: {
+      url: "https://api.cline.bot/api/v1/users/me/plan/usage-limits",
+    },
   },
   // Model IDs follow the documented `{provider}/{model}` format.
   // `cline-pass/` prefix is required by the Cline API for ClinePass models.
@@ -59,6 +65,10 @@ export default {
   thinkingConfig: {
     options: ["auto", "on", "off"],
     defaultMode: "auto",
+  },
+  features: {
+    usage: true,
+    usageApikey: true,
   },
 };
 

--- a/open-sse/services/circuitBreaker.js
+++ b/open-sse/services/circuitBreaker.js
@@ -78,6 +78,12 @@ function emit(provider) {
 /**
  * Should traffic to this provider be blocked right now?
  * Returns true if the breaker is OPEN (block) or HALF_OPEN at capacity.
+ *
+ * NOTE: this function has a SIDE EFFECT — in HALF_OPEN state it atomically
+ * claims a probe slot (increments halfOpenCalls). Use it at the point where
+ * you actually intend to send traffic. For a read-only "would this be blocked?"
+ * check (e.g. pre-filtering a combo model list), use `isBreakerBlocking()`
+ * instead to avoid consuming probe slots.
  */
 export function isCircuitOpen(provider, settings = {}) {
   const cfg = { ...BREAKER_DEFAULTS, ...(settings?.circuitBreaker || {}) };
@@ -107,6 +113,44 @@ export function isCircuitOpen(provider, settings = {}) {
   }
 
   return false; // CLOSED or HALF_OPEN with capacity → allow
+}
+
+/**
+ * Read-only check: would traffic to this provider be blocked right now?
+ *
+ * Mirrors the blocking logic of `isCircuitOpen` WITHOUT claiming a probe slot
+ * or transitioning state. Use this for pre-filtering (e.g. skipping
+ * breaker-open models from a combo list before attempting them) so we don't
+ * consume the single HALF_OPEN probe slot during a read-only inspection.
+ *
+ * A model flagged blocking here is skipped proactively; if every model is
+ * flagged (combo fully depleted), callers should still attempt the original
+ * list as a last resort because the lazy OPEN→HALF_OPEN transition inside
+ * isCircuitOpen may have fired by the time the attempt runs.
+ */
+export function isBreakerBlocking(provider, settings = {}) {
+  const cfg = { ...BREAKER_DEFAULTS, ...(settings?.circuitBreaker || {}) };
+  if (!cfg.enabled) return false;
+
+  const b = breakers.get(provider);
+  if (!b) return false; // no state = never tripped = not blocking
+
+  const now = Date.now();
+
+  if (b.state === "open") {
+    // If cooldown elapsed, the next real isCircuitOpen call will transition to
+    // HALF_OPEN — so from a read-only view we consider it NOT blocking (the
+    // attempt should proceed so isCircuitOpen can claim the probe).
+    if (b.cooldownEndsAt && now >= b.cooldownEndsAt) return false;
+    return true; // still in cooldown → blocking
+  }
+
+  if (b.state === "halfOpen") {
+    // At capacity = a probe is already in flight → additional traffic blocked.
+    return b.halfOpenCalls >= cfg.halfOpenMaxCalls;
+  }
+
+  return false; // CLOSED → not blocking
 }
 
 /**
@@ -172,7 +216,7 @@ export function recordBreakerFailure(provider, status, settings = {}) {
  * Without this, the slot leaks and the breaker sticks at capacity indefinitely.
  */
 export function releaseBreakerProbe(provider) {
-  const b = monitors.get(provider);
+  const b = breakers.get(provider);
   if (!b || b.state !== "halfOpen") return;
   if (b.halfOpenCalls > 0) {
     b.halfOpenCalls--;

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -6,10 +6,70 @@ import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
+import { isBreakerBlocking } from "./circuitBreaker.js";
+import REGISTRY from "../providers/registry/index.js";
 
 // Hard capabilities = input modalities; missing one drops request data (e.g. image
 // stripped). Must be prioritized. Soft (e.g. search) only degrades a feature.
 const HARD_CAPS = new Set(["vision", "pdf", "audioInput", "videoInput"]);
+
+// Alias → provider id map (built once from the registry). Combo model strings
+// use the provider ALIAS as the prefix (e.g. "glm/glm-5", "gh/claude-opus"),
+// but the circuit breaker is keyed by provider ID. This map resolves the prefix
+// so we can ask the breaker about the right provider without crossing the
+// open-sse → src layer boundary.
+const ALIAS_TO_ID = new Map();
+for (const entry of REGISTRY) {
+  if (entry.alias) ALIAS_TO_ID.set(entry.alias, entry.id);
+  if (Array.isArray(entry.aliases)) {
+    for (const a of entry.aliases) ALIAS_TO_ID.set(a, entry.id);
+  }
+  // Also map id → id so a combo model already using the id prefix resolves.
+  ALIAS_TO_ID.set(entry.id, entry.id);
+}
+
+/**
+ * Pre-filter a combo's model list: drop models whose provider circuit breaker
+ * is currently OPEN (blocking traffic). This avoids a wasted credential-
+ * selection round-trip per broken model before the reactive fallback path
+ * would have skipped it anyway.
+ *
+ * Read-only: uses isBreakerBlocking (no probe-slot claiming), so it's safe to
+ * call without consuming the single HALF_OPEN probe allotment.
+ *
+ * If EVERY model is breaker-blocked, returns the original list unchanged —
+ * the lazy OPEN→HALF_OPEN transition inside isCircuitOpen may have fired by
+ * the time we actually attempt, so we don't hard-block a fully-depleted combo.
+ * The worst case is one extra failed attempt, which is strictly better than
+ * refusing to serve a request that could have succeeded.
+ *
+ * @param {string[]} models - combo model strings ("provider/model")
+ * @param {object} breakerSettings - settings object (reads settings.circuitBreaker)
+ * @returns {{ active: string[], skipped: string[] }}
+ */
+export function filterBreakerOpenModels(models, breakerSettings) {
+  if (!Array.isArray(models) || models.length <= 1) {
+    return { active: models || [], skipped: [] };
+  }
+  const active = [];
+  const skipped = [];
+  for (const m of models) {
+    const slash = typeof m === "string" ? m.indexOf("/") : -1;
+    const prefix = slash > 0 ? m.slice(0, slash) : "";
+    const providerId = prefix ? (ALIAS_TO_ID.get(prefix) || prefix) : "";
+    if (providerId && isBreakerBlocking(providerId, breakerSettings)) {
+      skipped.push(m);
+    } else {
+      active.push(m);
+    }
+  }
+  // Last-resort: if every model is blocked, return the original list. A probe
+  // window may open during the attempt, and one failed call beats a hard 503.
+  if (active.length === 0) {
+    return { active: models, skipped: [] };
+  }
+  return { active, skipped };
+}
 
 // Prefixes used when flattening tool turns into plain prose for panel models.
 const TOOL_CALL_PREFIX = "[Called tools: ";
@@ -129,7 +189,13 @@ export function detectRequiredCapabilities(body) {
   const contents = body.contents || body.request?.contents;                      // gemini / antigravity
   for (const c of trailingUserItems(contents)) scanContent(c.parts);
 
-  // search: temporarily disabled in auto-switch (feature not wired yet).
+  // Search capability detection is intentionally NOT implemented here. The
+  // tools array carries provider-specific search tool definitions whose shape
+  // varies across OpenAI/Claude/Gemini, and the combo auto-switch only needs
+  // to reorder for HARD input modalities (vision/pdf/audio/video). A model
+  // lacking search still answers — it just won't call the search tool — so
+  // there's no correctness reason to float search-capable models. Revisit if
+  // we ever want to prefer search-capable models for search-flagged requests.
 
   return required;
 }
@@ -163,10 +229,11 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
 
   const rotationKey = comboName || "__default__";
   const normalizedStickyLimit = normalizeStickyLimit(stickyLimit);
-  const existingState = comboRotationState.get(rotationKey);
-  const state = typeof existingState === "number"
-    ? { index: existingState, consecutiveUseCount: 0 }
-    : (existingState || { index: 0, consecutiveUseCount: 0 });
+  // State shape is always { index, consecutiveUseCount }. The previous version
+  // carried a legacy `typeof existingState === "number"` branch for an old
+  // on-disk format that was never persisted across restarts (comboRotationState
+  // is an in-memory Map) — dead code, removed.
+  const state = comboRotationState.get(rotationKey) || { index: 0, consecutiveUseCount: 0 };
 
   const currentIndex = state.index % models.length;
   const rotatedModels = rotateModelsFromIndex(models, currentIndex);
@@ -226,11 +293,24 @@ export function getComboModelsFromData(modelStr, combosData) {
  * @param {string} [options.comboName] - Name of the combo (for round-robin tracking)
  * @param {string} [options.comboStrategy] - Strategy: "fallback" or "round-robin"
  * @param {number|string} [options.comboStickyLimit=1] - Requests per combo model before switching
+ * @param {Object} [options.breakerSettings] - Settings (reads circuitBreaker config) for proactive breaker pre-filter
  * @returns {Promise<Response>}
  */
-export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true }) {
+export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true, breakerSettings = null }) {
   // Apply rotation strategy if enabled
   let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
+
+  // Proactive breaker pre-filter: skip models whose provider circuit breaker
+  // is currently OPEN. This avoids a wasted credential-selection round-trip
+  // per broken model (the reactive fallback path would skip them anyway, but
+  // only after a failed attempt). Read-only check — does not claim probe slots.
+  if (breakerSettings) {
+    const { active, skipped } = filterBreakerOpenModels(rotatedModels, breakerSettings);
+    if (skipped.length > 0) {
+      log.info("COMBO", `breaker pre-filter: skipped ${skipped.length} open-breaker model(s) [${skipped.join(", ")}]`);
+      rotatedModels = active;
+    }
+  }
 
   // Auto-switch: float models that satisfy the request's required capabilities to the front.
   if (autoSwitch) {
@@ -534,6 +614,9 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
   log.info("FUSION", `fan-out collected in ${Date.now() - t0}ms`);
 
   // 2. Collect successful answers.
+  // We keep the original Response object alongside the extracted text so that
+  // the single-survivor path can return it directly without re-running the
+  // model (which would waste a second inference call + be non-deterministic).
   const answers = [];
   for (let i = 0; i < settled.length; i++) {
     const res = settled[i];
@@ -546,7 +629,7 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
       const json = await res.clone().json();
       const text = extractPanelText(json);
       if (text) {
-        answers.push({ model, text });
+        answers.push({ model, text, res });
         log.info("FUSION", `Panel ${model} ok (${text.length} chars)`);
       } else {
         log.warn("FUSION", `Panel ${model} returned empty content`);
@@ -565,8 +648,20 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
     );
   }
   if (answers.length === 1) {
-    log.info("FUSION", `Only ${answers[0].model} succeeded — answering directly (no fusion)`);
-    return handleSingleModel(body, answers[0].model);
+    // Single-survivor fallback. We already have a valid panel response, but it
+    // was forced to stream:false (the panel needs complete prose for judging).
+    // If the client requested streaming, returning that non-streaming response
+    // would silently downgrade SSE→JSON and break clients waiting on an event
+    // stream. In that case, re-invoke the survivor with the ORIGINAL body so
+    // the stream flag (and tools) are honored. For non-streaming requests we
+    // return the panel response directly — no point re-billing the same call.
+    const wantsStream = body?.stream === true;
+    if (wantsStream) {
+      log.info("FUSION", `Only ${answers[0].model} succeeded — re-running with stream:true to honor client SSE request (no fusion)`);
+      return handleSingleModel(body, answers[0].model);
+    }
+    log.info("FUSION", `Only ${answers[0].model} succeeded — returning its response directly (no fusion, no re-run)`);
+    return answers[0].res;
   }
 
   // 4. Judge analyzes + writes one final answer (streams to client if requested).

--- a/open-sse/services/swarm.js
+++ b/open-sse/services/swarm.js
@@ -161,16 +161,49 @@ function parseStrategy(text) {
   if (!text) return null;
   // Strip markdown fences if present.
   const cleaned = text.replace(/```json\s*/gi, "").replace(/```/g, "").trim();
-  // Find the outermost JSON object.
+
+  // Attempt 1: full strict JSON parse of the outermost object.
   const start = cleaned.indexOf("{");
   const end = cleaned.lastIndexOf("}");
-  if (start === -1 || end === -1) return null;
-  try {
-    const obj = JSON.parse(cleaned.slice(start, end + 1));
-    if (Array.isArray(obj.subtasks) && obj.subtasks.length > 0) return obj;
-  } catch {
-    // fall through
+  if (start !== -1 && end !== -1 && end > start) {
+    try {
+      const obj = JSON.parse(cleaned.slice(start, end + 1));
+      if (Array.isArray(obj.subtasks) && obj.subtasks.length > 0) return obj;
+    } catch {
+      // fall through to lenient recovery
+    }
   }
+
+  // Attempt 2: lenient recovery for truncated JSON. Reasoning models that hit
+  // max_tokens mid-output produce a strategy whose trailing braces are missing,
+  // so the strict parse above fails. Salvage whatever complete subtask objects
+  // already landed on the wire: scan for each {...} block containing an "id"
+  // field and reconstruct a partial strategy. Partial is strictly better than
+  // discarding the Manager's decomposition and falling back to a direct answer
+  // (which abandons the whole swarm pipeline).
+  const subtaskBlocks = [];
+  const blockRe = /\{[^{}]*?"id"\s*:\s*\d+[^{}]*?\}/gs;
+  let match;
+  while ((match = blockRe.exec(cleaned)) !== null) {
+    const blockText = match[0];
+    try {
+      const parsed = JSON.parse(blockText);
+      if (parsed && (parsed.title || parsed.instruction || parsed.role)) {
+        subtaskBlocks.push({
+          id: typeof parsed.id === "number" ? parsed.id : subtaskBlocks.length + 1,
+          title: parsed.title || `Subtask ${subtaskBlocks.length + 1}`,
+          role: parsed.role || "default",
+          instruction: parsed.instruction || parsed.title || "",
+        });
+      }
+    } catch {
+      // skip unparseable individual block
+    }
+  }
+  if (subtaskBlocks.length > 0) {
+    return { assessment: "(recovered from truncated output)", subtasks: subtaskBlocks };
+  }
+
   return null;
 }
 
@@ -234,7 +267,7 @@ async function runManagerStrategy({ runId, body, managerModel, handleSingleModel
   }
 }
 
-async function dispatchWorkers({ runId, strategy, models, handleSingleModel, cfg, log }) {
+async function dispatchWorkers({ runId, strategy, models, body, handleSingleModel, cfg, log }) {
   markStageStart(runId, "workers", { workerCount: strategy.subtasks.length });
   const subtasks = strategy.subtasks;
   const workerModels = models.filter(Boolean);
@@ -244,10 +277,13 @@ async function dispatchWorkers({ runId, strategy, models, handleSingleModel, cfg
   }
 
   // Assign each subtask to a worker model (round-robin across available combo models).
+  // `body` is threaded explicitly (NOT via module-level ref) to be safe under
+  // concurrent swarm requests — a module-level ref would let two in-flight
+  // requests clobber each other's prompt (cross-request leak + wrong output).
   const calls = subtasks.map((subtask, i) => {
     const workerModel = workerModels[i % workerModels.length];
     // Workers get FULL unsanitized context (no IDE strip) + specialist directive as user turn.
-    const workerBody = appendUserTurn(buildPanelBody(body_global), buildWorkerDirective(subtask));
+    const workerBody = appendUserTurn(buildPanelBody(body), buildWorkerDirective(subtask));
     markWorkerStatus(runId, i, "running", { model: workerModel });
     return withTimeout(handleSingleModel(workerBody, workerModel, true), cfg.workerHardTimeoutMs)
       .then(async (res) => {
@@ -280,7 +316,7 @@ async function dispatchWorkers({ runId, strategy, models, handleSingleModel, cfg
   return outputs;
 }
 
-async function runStaffAudit({ runId, strategy, workerOutputs, staffModel, auditModel, handleSingleModel, cfg, log }) {
+async function runStaffAudit({ runId, strategy, workerOutputs, staffModel, auditModel, body, handleSingleModel, cfg, log }) {
   const model = staffModel || auditModel;
   if (!model) {
     markStageDone(runId, "audit", { skipped: true });
@@ -291,7 +327,7 @@ async function runStaffAudit({ runId, strategy, workerOutputs, staffModel, audit
     const match = workerOutputs.find((w) => w.subtask?.id === st.id);
     return { ...st, output: match?.text || "(no output)" };
   });
-  const auditBody = stripIdeSystemPrompt(buildPanelBody(body_global));
+  const auditBody = stripIdeSystemPrompt(buildPanelBody(body));
   const directiveBody = appendUserTurn(auditBody, buildStaffAuditPrompt(subtasksWithOutputs, workerOutputs.map((w) => w.text)));
 
   try {
@@ -310,10 +346,10 @@ async function runStaffAudit({ runId, strategy, workerOutputs, staffModel, audit
   }
 }
 
-// Body is threaded via a module-level ref because dispatchWorkers is invoked
-// as a map callback and can't easily take extra args without changing the
-// collectPanel contract. Set before fan-out, cleared after.
-let body_global = null;
+// NOTE: `body` is threaded explicitly through every stage runner (not via a
+// module-level ref). A module-level ref would be unsafe under concurrent swarm
+// requests in the same process — two in-flight runs would clobber each other's
+// prompt, leaking one user's content into the other's workers.
 
 // ── Main entry ────────────────────────────────────────────────────────────
 
@@ -349,7 +385,6 @@ export async function handleSwarmChat({
     return handleSingleModel(body, panel[0]);
   }
 
-  body_global = body;
   const run = telemetry
     ? createSwarmRun({
         comboName,
@@ -372,7 +407,6 @@ export async function handleSwarmChat({
       // Manager answers directly, streaming to client (original body preserved).
       log?.info?.("SWARM", "Gatekeeper bypass — simple request, direct answer");
       if (runId) markRunComplete(runId, { bypassed: true });
-      body_global = null;
       return handleSingleModel(body, manager);
     }
 
@@ -385,23 +419,25 @@ export async function handleSwarmChat({
       // Strategy parse failed → fall back to direct answer.
       log?.warn?.("SWARM", "Strategy decomposition failed — falling back to direct answer");
       if (runId) markRunComplete(runId, { fallback: true });
-      body_global = null;
       return handleSingleModel(body, manager);
     }
 
-    // Clamp worker count.
-    const effectiveSubtasks = strategy.subtasks.slice(0, cfg.maxWorkers);
+    // Clamp worker count: honor per-combo workerCount if set, else fall back to
+    // maxWorkers safety cap. This makes the UI's worker count field effective.
+    const workerCap = (typeof workerCount === "number" && workerCount > 0)
+      ? Math.min(workerCount, cfg.maxWorkers)
+      : cfg.maxWorkers;
+    const effectiveSubtasks = strategy.subtasks.slice(0, workerCap);
 
     // ── Stage 2+3: Dispatch Workers (parallel) ──
     const workerOutputs = telemetry
-      ? await dispatchWorkers({ runId, strategy: { subtasks: effectiveSubtasks }, models: panel, handleSingleModel, cfg, log })
-      : (await dispatchWorkersNoTelemetry({ strategy: { subtasks: effectiveSubtasks }, models: panel, handleSingleModel, cfg, log }));
+      ? await dispatchWorkers({ runId, strategy: { subtasks: effectiveSubtasks }, models: panel, body, handleSingleModel, cfg, log })
+      : (await dispatchWorkersNoTelemetry({ strategy: { subtasks: effectiveSubtasks }, models: panel, body, handleSingleModel, cfg, log }));
 
     if (workerOutputs.length < cfg.minWorkers) {
       // Too few workers succeeded → fall back to direct answer from best worker or manager.
       log?.warn?.("SWARM", `Only ${workerOutputs.length}/${effectiveSubtasks.length} workers succeeded — fallback`);
       if (runId) markRunComplete(runId, { fallback: true });
-      body_global = null;
       if (workerOutputs.length === 1) {
         // Return the single worker's output directly.
         return handleSingleModel(appendUserTurn(body, "The specialist worker produced this answer. Output it verbatim to the user."), manager);
@@ -411,8 +447,8 @@ export async function handleSwarmChat({
 
     // ── Stage 4: Staff Audit ──
     const auditReport = telemetry
-      ? await runStaffAudit({ runId, strategy: { subtasks: effectiveSubtasks }, workerOutputs, staffModel, auditModel, handleSingleModel, cfg, log })
-      : (await runStaffAuditNoTelemetry({ strategy: { subtasks: effectiveSubtasks }, workerOutputs, staffModel, auditModel, handleSingleModel, cfg, log }));
+      ? await runStaffAudit({ runId, strategy: { subtasks: effectiveSubtasks }, workerOutputs, staffModel, auditModel, body, handleSingleModel, cfg, log })
+      : (await runStaffAuditNoTelemetry({ strategy: { subtasks: effectiveSubtasks }, workerOutputs, staffModel, auditModel, body, handleSingleModel, cfg, log }));
 
     // ── Stage 5: Manager Synthesis (STREAMED to client) ──
     const synthesisDirective = auditReport
@@ -429,16 +465,13 @@ export async function handleSwarmChat({
       const res = await handleSingleModel(synthBody, manager);
       markStageDone(runId, "synthesis");
       markRunComplete(runId, { workerCount: workerOutputs.length });
-      body_global = null;
       return res;
     }
 
-    body_global = null;
     return handleSingleModel(synthBody, manager);
   } catch (e) {
     log?.error?.("SWARM", `Swarm failed: ${e?.message || e}`);
     if (runId) markRunError(runId, e);
-    body_global = null;
     // Graceful degradation: fall back to direct answer on any uncaught error.
     return handleSingleModel(body, manager);
   }
@@ -473,12 +506,12 @@ async function runManagerStrategyNoTelemetry({ body, managerModel, handleSingleM
   }
 }
 
-async function dispatchWorkersNoTelemetry({ strategy, models, handleSingleModel, cfg }) {
+async function dispatchWorkersNoTelemetry({ strategy, models, body, handleSingleModel, cfg }) {
   const workerModels = models.filter(Boolean);
   if (workerModels.length === 0) return [];
   const calls = strategy.subtasks.map((subtask, i) => {
     const workerModel = workerModels[i % workerModels.length];
-    const workerBody = appendUserTurn(buildPanelBody(body_global), buildWorkerDirective(subtask));
+    const workerBody = appendUserTurn(buildPanelBody(body), buildWorkerDirective(subtask));
     return withTimeout(handleSingleModel(workerBody, workerModel, true), cfg.workerHardTimeoutMs);
   });
   const settled = await collectPanel(calls, {
@@ -497,14 +530,14 @@ async function dispatchWorkersNoTelemetry({ strategy, models, handleSingleModel,
   return outputs;
 }
 
-async function runStaffAuditNoTelemetry({ strategy, workerOutputs, staffModel, auditModel, handleSingleModel, cfg }) {
+async function runStaffAuditNoTelemetry({ strategy, workerOutputs, staffModel, auditModel, body, handleSingleModel, cfg }) {
   const model = staffModel || auditModel;
   if (!model) return null;
   const subtasksWithOutputs = strategy.subtasks.map((st, i) => {
     const match = workerOutputs.find((w) => w.subtask?.id === st.id);
     return { ...st, output: match?.text || "(no output)" };
   });
-  const auditBody = stripIdeSystemPrompt(buildPanelBody(body_global));
+  const auditBody = stripIdeSystemPrompt(buildPanelBody(body));
   const directiveBody = appendUserTurn(auditBody, buildStaffAuditPrompt(subtasksWithOutputs, workerOutputs.map((w) => w.text)));
   try {
     const res = await withTimeout(handleSingleModel(directiveBody, model, true), cfg.managerTimeoutMs);

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -21,6 +21,7 @@ import {
 } from "./usage/misc.js";
 import { getXaiUsage } from "./usage/xai.js";
 import { getTokenRouterUsage } from "./usage/tokenrouter.js";
+import { getClineUsage } from "./usage/cline.js";
 
 /**
  * Get usage data for a provider connection
@@ -47,6 +48,10 @@ const USAGE_HANDLERS = {
   "codebuddy-cn": (c) => getCodeBuddyCnUsage(c.accessToken, c.apiKey, c.providerSpecificData, c.proxyOptions),
   xai: (c) => getXaiUsage(c, c.proxyOptions),
   tokenrouter: (c) => getTokenRouterUsage(c, c.providerSpecificData, c.proxyOptions),
+  // Cline + ClinePass share the same upstream host and plan-limits endpoint;
+  // a single handler serves both providers.
+  cline: (c) => getClineUsage({ accessToken: c.accessToken, apiKey: c.apiKey }, c.proxyOptions),
+  clinepass: (c) => getClineUsage({ accessToken: c.accessToken, apiKey: c.apiKey }, c.proxyOptions),
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null) {

--- a/open-sse/services/usage/cline.js
+++ b/open-sse/services/usage/cline.js
@@ -1,0 +1,106 @@
+// Cline / ClinePass usage handler for Quota Tracker.
+//
+// Both providers share the same upstream API host (api.cline.bot) and the same
+// plan-limits endpoint:
+//   GET /api/v1/users/me/plan/usage-limits
+//   Authorization: Bearer <accessToken | apiKey>
+//
+// Response shape:
+//   { data: { limits: [
+//     { type: "five_hour", percentUsed: 0 },
+//     { type: "weekly",    percentUsed: 51, resetsAt: "2026-07-25T..." },
+//     { type: "monthly",   percentUsed: 100, resetsAt: "2026-08-03T..." },
+//   ] }, success: true }
+//
+// The API only exposes percentUsed (no absolute token/request counts), so each
+// quota is normalized as used=percentUsed / total=100. The Quota Tracker UI
+// derives the remaining% from these and renders the bar accordingly. The
+// "N / 100" text under the bar reads naturally as "percent used of cap".
+//
+// Works with BOTH auth modes:
+//   - OAuth connections: uses the OAuth access token (preferred)
+//   - API-key connections: uses the sk-... API key directly
+// `features.usage` + `features.usageApikey` are both set on the registry so
+// either connection type is eligible for tracking.
+
+import { U, parseResetTime, toFiniteNumber } from "./shared.js";
+import { proxyAwareFetch } from "../../utils/proxyFetch.js";
+
+const USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+
+// Human-readable labels for each limit window Cline exposes. Order matters for
+// stable card layout (shortest window first — matches the API array order).
+const LIMIT_LABELS = {
+  five_hour: "5-Hour",
+  weekly: "Weekly",
+  monthly: "Monthly",
+};
+
+export async function getClineUsage(credentials, proxyOptions = null) {
+  // Prefer OAuth access token, fall back to API key for api-key connections.
+  // Both are sent as Bearer tokens against the same Cline endpoint.
+  const token = credentials?.accessToken || credentials?.apiKey;
+  if (!token) return null;
+
+  const cfg = U("cline");
+  const url = cfg.url || "https://api.cline.bot/api/v1/users/me/plan/usage-limits";
+
+  const res = await proxyAwareFetch(
+    url,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": USER_AGENT,
+      },
+    },
+    proxyOptions,
+  );
+
+  if (!res?.ok) {
+    // Non-fatal: the Quota Tracker shows an empty card on failure. Keep a
+    // concise reason in the message field so the card isn't silently blank.
+    return {
+      quotas: {},
+      plan: null,
+      message: `Cline usage request failed (${res?.status || "no response"})`,
+    };
+  }
+
+  const body = await res.json().catch(() => null);
+  const limits = Array.isArray(body?.data?.limits) ? body.data.limits : [];
+
+  const quotas = {};
+  for (const limit of limits) {
+    const key = LIMIT_LABELS[limit?.type] || limit?.type || "Unknown";
+    const percentUsed = toFiniteNumber(limit?.percentUsed, 0);
+    // Clamp 0–100 — the API has been observed returning values outside range
+    // during edge cases (e.g. 100 for an exhausted monthly cap). Defensive.
+    const clamped = Math.max(0, Math.min(100, percentUsed));
+
+    quotas[key] = {
+      // Percentage-carrier shape: used/total out of 100. The UI's
+      // getRemainingPercentage() derives `100 - used` from this directly.
+      used: clamped,
+      total: 100,
+      // Explicit remaining so the table never falls back to calculatePercentage
+      // (which would re-derive the same number, but be explicit).
+      remainingPercentage: 100 - clamped,
+      resetAt: parseResetTime(limit?.resetsAt) || null,
+    };
+  }
+
+  if (Object.keys(quotas).length === 0) {
+    return {
+      quotas: {},
+      plan: null,
+      message: "Cline returned no usage limits for this account.",
+    };
+  }
+
+  return {
+    quotas,
+    plan: null,
+  };
+}

--- a/open-sse/services/usage/xai.js
+++ b/open-sse/services/usage/xai.js
@@ -21,26 +21,20 @@
 // Reference: github.com/decolua/9router PR #2672 (original implementation
 // against the now-defunct endpoints).
 
-import { U } from "./shared.js";
-
-// Kept for forward-compatibility: if a Management API key is ever wired up
+// Forward-compat hook: if a Management API key is ever wired up
 // (providerSpecificData.mgmtKey, mirroring TokenRouter), this handler can be
 // re-enabled against https://management-api.x.ai/billing without touching the
 // registration in services/usage.js.
 export async function getXaiUsage(credentials, _proxyOptions = null) {
-  // Sanity reference — confirms the provider config still exists. Intentionally
-  // unused for network calls while the handler is in the informational state.
-  void U;
-
   const hasMgmtKey = Boolean(
     credentials?.providerSpecificData?.mgmtKey ||
       credentials?.providerDataWithProjectId?.mgmtKey
   );
 
   if (hasMgmtKey) {
-    // Forward-compat hook: if a Management Key is present we still cannot reach
-    // a documented billing endpoint today, but we acknowledge the credential
-    // so the message can guide the user.
+    // If a Management Key is present we still cannot reach a documented billing
+    // endpoint today, but we acknowledge the credential so the message can
+    // guide the user.
     return {
       quotas: {},
       plan: null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsalmn/extremerouter-app",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "ExtremeRouter web dashboard",
   "private": true,
   "license": "MIT",

--- a/src/app/(dashboard)/dashboard/combos/CombosPageInner.js
+++ b/src/app/(dashboard)/dashboard/combos/CombosPageInner.js
@@ -87,21 +87,71 @@ export default function CombosPageInner() {
         try {
           const res = await fetch(`/api/combos/${id}`, { method: "DELETE" });
           // H5 FIX: Use functional update to avoid stale closure on `combos`
-          if (res.ok) setCombos(prev => prev.filter((c) => c.id !== id));
-        } catch (error) { console.log("Error deleting combo:", error); }
+          if (res.ok) {
+            setCombos(prev => prev.filter((c) => c.id !== id));
+          } else {
+            // M5 FIX: previously silent on failure — card stayed in the list
+            // with no indication the delete was rejected. Surface the error.
+            const err = await res.json().catch(() => ({}));
+            alert(err.error || `Failed to delete combo (${res.status})`);
+          }
+        } catch (error) {
+          console.log("Error deleting combo:", error);
+          alert("Failed to delete combo — network error");
+        }
       },
     });
   };
 
   const handleSetComboStrategy = async (comboName, patch) => {
+    // H2 FIX: send ONLY the changed combo entry instead of the full
+    // comboStrategies snapshot. The backend now deep-merges comboStrategies
+    // at the combo-name level (settingsRepo.updateSettings), so a concurrent
+    // edit to a different combo survives. Previously the full-map PATCH raced
+    // with other edits and the last writer silently dropped the others.
+    //
+    // L4 FIX: when the strategy changes, strip stale role-specific fields from
+    // the previous strategy so they don't accumulate forever (e.g. switching
+    // fusion→swarm previously left judgeModel sitting unused in settings, and
+    // swarm→fusion left managerModel/staffModel/auditModel). Strip the fields
+    // the new strategy doesn't use before sending.
     try {
-      const updated = { ...comboStrategies };
-      const next = { ...(updated[comboName] || {}), ...patch };
-      if (!next.fallbackStrategy || next.fallbackStrategy === "fallback") delete updated[comboName];
-      else updated[comboName] = next;
-      await fetch("/api/settings", { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ comboStrategies: updated }) });
-      setComboStrategies(updated);
-    } catch (error) { console.log("Error updating combo strategy:", error); }
+      const current = (comboStrategies[comboName] || {});
+      const merged = { ...current, ...patch };
+      const nextStrat = merged.fallbackStrategy;
+
+      // Fields each strategy actually uses. Everything else is stale.
+      const ROLE_FIELDS = {
+        fusion: ["judgeModel", "fusionTuning"],
+        swarm: ["managerModel", "staffModel", "auditModel", "workerCount", "swarmTuning", "enableTelemetry"],
+        fallback: [],
+        "round-robin": [],
+      };
+      const keep = new Set(["fallbackStrategy", ...(ROLE_FIELDS[nextStrat] || [])]);
+      const next = {};
+      for (const [k, v] of Object.entries(merged)) {
+        if (keep.has(k)) next[k] = v;
+      }
+
+      const isDelete = !next.fallbackStrategy || next.fallbackStrategy === "fallback";
+      // null is the backend's delete-signal (see settingsRepo deep-merge).
+      const payload = { comboStrategies: { [comboName]: isDelete ? null : next } };
+
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      setComboStrategies((prev) => {
+        const updated = { ...prev };
+        if (isDelete) delete updated[comboName];
+        else updated[comboName] = next;
+        return updated;
+      });
+    } catch (error) {
+      console.log("Error updating combo strategy:", error);
+    }
   };
 
   if (loading) {

--- a/src/app/(dashboard)/dashboard/combos/components/ComboCard.js
+++ b/src/app/(dashboard)/dashboard/combos/components/ComboCard.js
@@ -13,6 +13,12 @@ export default function ComboCard({ combo, modelCaps = {}, activeProviders = [],
   const [showJudgeSelect, setShowJudgeSelect] = useState(false);
   const [showSwarmRoleSelect, setShowSwarmRoleSelect] = useState(null);
 
+  // M4 FIX: defensive default — combo.models can be undefined if the combos
+  // list was fetched mid-write or a row was hand-edited. ComboOverview guards
+  // with ?. but ComboCard previously crashed on .length/.slice/.map. Normalize
+  // once at the top so every downstream use is safe.
+  const models = Array.isArray(combo?.models) ? combo.models : [];
+
   const current = strategy.fallbackStrategy || "fallback";
   const judge = strategy.judgeModel || "";
   const isFusion = current === "fusion";
@@ -43,22 +49,22 @@ export default function ComboCard({ combo, modelCaps = {}, activeProviders = [],
             <div className="flex items-center gap-2">
               <code className="truncate font-mono text-sm font-medium">{combo.name}</code>
               <Badge variant={meta.badge} size="sm">{getStrategyLabel(current)}</Badge>
-              <span className="text-[10px] text-text-muted">{combo.models.length} models</span>
+              <span className="text-[10px] text-text-muted">{models.length} models</span>
             </div>
             {/* Model chips — first 3 + "+N more" */}
             <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1">
-              {combo.models.length === 0 ? (
+              {models.length === 0 ? (
                 <span className="text-xs text-text-muted italic">No models</span>
               ) : (
-                combo.models.slice(0, 3).map((model, index) => (
+                models.slice(0, 3).map((model, index) => (
                   <code key={index} className="inline-flex items-center gap-1 rounded bg-black/5 px-1.5 py-0.5 font-mono text-xs text-text-muted dark:bg-white/5">
                     <span className="truncate max-w-[120px]">{model}</span>
                     {modelCaps[model] && <CapacityBadges caps={modelCaps[model]} size={11} />}
                   </code>
                 ))
               )}
-              {combo.models.length > 3 && (
-                <span className="text-[10px] text-text-muted">+{combo.models.length - 3} more</span>
+              {models.length > 3 && (
+                <span className="text-[10px] text-text-muted">+{models.length - 3} more</span>
               )}
             </div>
           </div>
@@ -104,9 +110,9 @@ export default function ComboCard({ combo, modelCaps = {}, activeProviders = [],
         <div className="mt-3 border-t border-border-subtle pt-3">
           {/* Full model list */}
           <div className="mb-3">
-            <p className="text-[10px] uppercase tracking-wide text-text-muted mb-1.5">Models ({combo.models.length})</p>
+            <p className="text-[10px] uppercase tracking-wide text-text-muted mb-1.5">Models ({models.length})</p>
             <div className="flex flex-col gap-1">
-              {combo.models.map((model, index) => (
+              {models.map((model, index) => (
                 <div key={index} className="flex items-center gap-2 rounded px-2 py-1 bg-black/[0.02] dark:bg-white/[0.02]">
                   <span className="text-[10px] font-medium text-text-muted w-4 text-center">{index + 1}</span>
                   <code className="min-w-0 flex-1 truncate font-mono text-xs text-text-main">{model}</code>
@@ -126,7 +132,7 @@ export default function ComboCard({ combo, modelCaps = {}, activeProviders = [],
                   className="inline-flex max-w-full items-center gap-1 rounded border border-dashed border-primary/40 px-2 py-1 font-mono text-xs text-primary hover:border-primary hover:bg-primary/5"
                 >
                   <span className="material-symbols-outlined text-[14px]">gavel</span>
-                  <span className="truncate">{judge || `Auto — ${combo.models[0] || "first model"}`}</span>
+                  <span className="truncate">{judge || `Auto — ${models[0] || "first model"}`}</span>
                 </button>
                 {judge && (
                   <button onClick={() => onSetStrategy({ judgeModel: "" })} className="p-1 rounded text-text-muted hover:text-red-500 hover:bg-red-500/10" title="Reset to Auto">
@@ -143,7 +149,7 @@ export default function ComboCard({ combo, modelCaps = {}, activeProviders = [],
               <p className="text-[10px] uppercase tracking-wide text-text-muted mb-1.5">Swarm Roles</p>
               <div className="flex flex-col gap-1.5">
                 {[
-                  { key: "manager", label: "Manager", icon: "psychology", value: swarmManager, placeholder: `Auto — ${combo.models[0] || "first"}` },
+                  { key: "manager", label: "Manager", icon: "psychology", value: swarmManager, placeholder: `Auto — ${models[0] || "first"}` },
                   { key: "staff", label: "Staff", icon: "badge", value: swarmStaff, placeholder: "Same as Manager" },
                   { key: "audit", label: "Audit", icon: "fact_check", value: swarmAudit, placeholder: "Same as Staff" },
                 ].map((role) => (
@@ -165,7 +171,7 @@ export default function ComboCard({ combo, modelCaps = {}, activeProviders = [],
                 ))}
                 <div className="flex items-center gap-2 text-[11px] text-text-muted">
                   <span className="font-medium">Workers</span>
-                  <span>= combo models ({combo.models.length})</span>
+                  <span>= combo models ({models.length})</span>
                   <span className="text-text-subtle">·</span>
                   <a href="/dashboard/swarm" className="text-primary hover:underline">Telemetry →</a>
                 </div>
@@ -199,7 +205,15 @@ export default function ComboCard({ combo, modelCaps = {}, activeProviders = [],
           onSelect={(m) => { onSetStrategy({ [`${showSwarmRoleSelect}Model`]: m?.value || "" }); setShowSwarmRoleSelect(null); }}
           activeProviders={activeProviders}
           title={`Select ${showSwarmRoleSelect === "manager" ? "Manager" : showSwarmRoleSelect === "staff" ? "Staff" : "Audit"} Model`}
-          addedModelValues={[]}
+          // L5 FIX: highlight the currently-selected model for this role so the
+          // user sees which one is already set (consistent with the judge picker
+          // above which passes `judge ? [judge] : []`). Previously this was []
+          // always, so no selection was ever shown.
+          addedModelValues={
+            showSwarmRoleSelect === "manager" ? (swarmManager ? [swarmManager] : [])
+            : showSwarmRoleSelect === "staff" ? (swarmStaff ? [swarmStaff] : [])
+            : (swarmAudit ? [swarmAudit] : [])
+          }
           closeOnSelect={true}
         />
       )}

--- a/src/app/(dashboard)/dashboard/combos/components/ComboFormModal.js
+++ b/src/app/(dashboard)/dashboard/combos/components/ComboFormModal.js
@@ -24,6 +24,22 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
   const [nameError, setNameError] = useState("");
   const [modelAliases, setModelAliases] = useState({});
 
+  // H3 FIX: reset local draft whenever the modal is (re)opened. The parent
+  // mounts the create modal once with a static key, so useState initializers
+  // only ran on first mount — reopening Create after closing showed the
+  // previous session's name/models. Re-seed from the `combo` prop (undefined
+  // for create) on each open transition so the form starts clean.
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  useEffect(() => {
+    if (isOpen && !wasOpen) {
+      setName(combo?.name || "");
+      setModels(Array.isArray(combo?.models) ? [...combo.models] : []);
+      setNameError("");
+      setShowModelSelect(false);
+    }
+    setWasOpen(isOpen);
+  }, [isOpen, wasOpen, combo]);
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -44,15 +60,20 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
 
   useEffect(() => {
     if (!isOpen) return;
+    // L9 FIX: guard against setState-after-unmount. If the modal closes while
+    // the fetch is in flight, the cancelled flag prevents a state update on an
+    // unmounted component (React warning + potential memory leak).
+    let cancelled = false;
     (async () => {
       try {
         const res = await fetch("/api/models/alias");
-        if (res.ok) {
+        if (!cancelled && res.ok) {
           const data = await res.json();
           setModelAliases(data.aliases || {});
         }
       } catch { /* non-fatal */ }
     })();
+    return () => { cancelled = true; };
   }, [isOpen]);
 
   const validateName = (value) => {
@@ -70,15 +91,17 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
   };
 
   const handleAddModel = (model) => {
-    if (!models.includes(model.value)) setModels([...models, model.value]);
+    // H4 FIX: functional update — reading `models` from the closure lost rapid
+    // adds before re-render (only the last survived). Derive from prev state.
+    setModels((prev) => (prev.includes(model.value) ? prev : [...prev, model.value]));
   };
 
   const handleDeselectModel = (model) => {
-    setModels(models.filter((m) => m !== model.value));
+    setModels((prev) => prev.filter((m) => m !== model.value));
   };
 
   const handleRemoveModel = (index) => {
-    setModels(models.filter((_, i) => i !== index));
+    setModels((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleMoveUp = (index) => {

--- a/src/app/(dashboard)/dashboard/combos/components/helpers.js
+++ b/src/app/(dashboard)/dashboard/combos/components/helpers.js
@@ -96,8 +96,15 @@ export function getUniqueModels(combos) {
 // Compute strategy distribution for donut/bar chart.
 export function getStrategyDistribution(combos, comboStrategies) {
   const dist = { fallback: 0, "round-robin": 0, fusion: 0, swarm: 0 };
+  // L1 FIX: only the 4 known strategies get buckets. A typo'd/unknown value
+  // (e.g. "FUSION" uppercase persisted before M2 normalization) previously
+  // created a stray key that ComboOverview rendered as "Fallback" via the
+  // getStrategyMeta fallback — masking the misconfiguration. Now unknown
+  // values are bucketed under fallback explicitly.
+  const KNOWN = new Set(["fallback", "round-robin", "fusion", "swarm"]);
   for (const c of combos) {
-    const s = comboStrategies[c.name]?.fallbackStrategy || "fallback";
+    const raw = comboStrategies[c.name]?.fallbackStrategy || "fallback";
+    const s = KNOWN.has(raw) ? raw : "fallback";
     dist[s] = (dist[s] || 0) + 1;
   }
   return dist;

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/CollapsibleSection.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/CollapsibleSection.js
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/shared/utils/cn";
+
+/**
+ * Reusable collapsible section for the provider detail page.
+ *
+ * Pattern from Combos ComboCard: a Card with padding="none", a clickable
+ * header row (icon + title + count + chevron), and a body that shows/hides.
+ * The `actions` prop renders right-aligned buttons in the header (e.g. the
+ * connections toolbar or models test-all).
+ *
+ * Unlike the old ProviderSection (chevron_right text rotate), this uses the
+ * expand_more icon with rotate-180 on expand — cleaner and matches the Combos
+ * page collapse affordance.
+ */
+export default function CollapsibleSection({
+  title,
+  icon,
+  count,
+  defaultExpanded = true,
+  actions = null,
+  children,
+  className,
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-panel border border-border-subtle bg-panel shadow-[var(--shadow-soft)]",
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2 px-4 py-3">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex min-w-0 items-center gap-2 text-left"
+          aria-expanded={expanded}
+        >
+          {icon && (
+            <span className="material-symbols-outlined text-[20px] text-text-muted">
+              {icon}
+            </span>
+          )}
+          <h2 className="truncate text-sm font-semibold text-text-main">
+            {title}
+          </h2>
+          {count !== undefined && count !== null && (
+            <span className="shrink-0 rounded-full bg-black/5 px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-text-muted dark:bg-white/10">
+              {count}
+            </span>
+          )}
+          <span
+            className={cn(
+              "material-symbols-outlined text-[18px] text-text-muted transition-transform",
+              expanded && "rotate-180",
+            )}
+          >
+            expand_more
+          </span>
+        </button>
+        {actions && (
+          <div className="flex shrink-0 items-center gap-1.5">{actions}</div>
+        )}
+      </div>
+
+      {/* Body */}
+      {expanded && (
+        <div className="border-t border-border-subtle">{children}</div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionsCard.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionsCard.js
@@ -1,0 +1,445 @@
+"use client";
+
+import {
+  Button,
+  Toggle,
+  Modal,
+} from "@/shared/components";
+import { translate } from "@/i18n/runtime";
+import ConnectionRow from "../ConnectionRow";
+import VaultPoolBadge from "../VaultPoolBadge";
+import FreeBuffProfile from "../FreeBuffProfile";
+import V0Profile from "../V0Profile";
+import QwenCloudProfile from "../QwenCloudProfile";
+import ZenmuxPlanSelector from "../ZenmuxPlanSelector";
+import NoAuthProxyCard from "@/shared/components/NoAuthProxyCard";
+
+/**
+ * Connections card — extracted from page.js lines 1387-1643 + connectionsList
+ * (892-949) + bulkActionModal (953-1000). All state and handlers live in the
+ * parent page.js and are passed down via props. Visual polish: Card
+ * padding="none", header section with border-b, cleaner toolbar layout,
+ * progress-bar-style one-by-one summary, compact pill buttons.
+ *
+ * Behavioral logic is UNCHANGED — this is a pure extraction + restyle.
+ */
+export default function ConnectionsCard({
+  // identity
+  providerId,
+  isOAuth,
+  isCompatible,
+  isFreeNoAuth,
+  hasDualAuthModes,
+  oauthConnectionLabel,
+  apiKeyConnectionLabel,
+  thinkingConfig,
+  AUTO_PING_SETTINGS_KEYS,
+
+  // data
+  connections,
+  proxyPools,
+  selectedConnectionIds,
+  selectedConnections,
+  allSelected,
+  oneByOneRunning,
+  oneByOneStopping,
+  oneByOneCurrentConnectionId,
+  oneByOneResults,
+  oneByOneSummary,
+  providerStrategy,
+  providerStickyLimit,
+  thinkingMode,
+  autoPing,
+
+  // modal state
+  showBulkProxyModal,
+  bulkUpdatingProxy,
+  activePools,
+  selectedProxySummary,
+
+  // handlers
+  handleSwapPriority,
+  handleUpdateConnectionStatus,
+  handleDelete,
+  handleBulkDelete,
+  handleRunOneByOneTest,
+  handleStopOneByOneTest,
+  handleRoundRobinToggle,
+  handleStickyLimitChange,
+  handleThinkingModeChange,
+  handleAutoPingConnection,
+  triggerOAuthConnection,
+  triggerApiKeyConnection,
+  triggerAddConnection,
+  toggleSelectConnection,
+  toggleSelectAllConnections,
+  openBulkProxyModal,
+  closeBulkProxyModal,
+  applyProxyAssignments,
+  handleApplySinglePool,
+  handleApplyOneToOne,
+  fetchConnections,
+  setSelectedConnection,
+  setShowEditModal,
+  setShowBulkProxyModal,
+  setShowIFlowCookieModal,
+  setShowBulkImportCodex,
+  setConnections,
+}) {
+  // ── noAuth providers: delegate entirely to NoAuthProxyCard ──
+  if (isFreeNoAuth) {
+    return <NoAuthProxyCard providerId={providerId} />;
+  }
+
+  const isSelected = (connectionId) => selectedConnectionIds.includes(connectionId);
+
+  return (
+    <div className="flex flex-col">
+      {/* ── Header: title + provider widgets + toolbar ── */}
+      <div className="flex flex-col gap-3 border-b border-border-subtle px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-text-main">Connections</h3>
+            {connections.length > 0 && (
+              <span className="rounded-full bg-black/5 px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-text-muted dark:bg-white/10">
+                {connections.length}
+              </span>
+            )}
+          </div>
+          <VaultPoolBadge providerId={providerId} />
+          {providerId === "freebuff-web" && connections.length > 0 && (
+            <FreeBuffProfile connectionId={connections[0].id} />
+          )}
+          {providerId === "v0-vercel-web" && connections.length > 0 && (
+            <V0Profile connectionId={connections[0].id} />
+          )}
+          {providerId === "qwencloud" && connections.length > 0 && (
+            <QwenCloudProfile connectionId={connections[0].id} />
+          )}
+        </div>
+
+        {/* Toolbar: wraps on mobile, row on desktop */}
+        <div className="flex flex-wrap items-center gap-2">
+          {connections.length > 0 && proxyPools.length > 0 && (
+            <Button size="sm" variant="secondary" icon="lan" onClick={openBulkProxyModal}>
+              Apply Proxy
+            </Button>
+          )}
+          {connections.length > 0 && selectedConnectionIds.length > 0 && (
+            <Button size="sm" variant="danger" icon="delete" onClick={handleBulkDelete}>
+              Delete ({selectedConnectionIds.length})
+            </Button>
+          )}
+          {connections.length > 0 && (
+            <>
+              <Button
+                size="sm"
+                variant="secondary"
+                icon={oneByOneRunning ? "progress_activity" : "sync"}
+                onClick={handleRunOneByOneTest}
+                disabled={oneByOneRunning}
+                className={oneByOneRunning ? "animate-pulse" : ""}
+              >
+                {oneByOneRunning ? "Testing..." : "Test All"}
+              </Button>
+              {oneByOneRunning && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  icon="stop"
+                  onClick={handleStopOneByOneTest}
+                  disabled={oneByOneStopping}
+                >
+                  {oneByOneStopping ? "Stopping" : "Stop"}
+                </Button>
+              )}
+            </>
+          )}
+          {thinkingConfig && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-[10px] uppercase tracking-wide text-text-muted">Thinking</span>
+              <select
+                value={thinkingMode}
+                onChange={(e) => handleThinkingModeChange(e.target.value)}
+                className="h-7 rounded-lg border border-border bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-surface-2 dark:border-white/10 dark:bg-white/[0.03]"
+              >
+                {thinkingConfig.options.map((opt) => (
+                  <option key={opt} value={opt}>{opt.charAt(0).toUpperCase() + opt.slice(1)}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] uppercase tracking-wide text-text-muted">Round Robin</span>
+            <Toggle checked={providerStrategy === "round-robin"} onChange={handleRoundRobinToggle} />
+            {providerStrategy === "round-robin" && (
+              <input
+                type="number"
+                min={1}
+                value={providerStickyLimit}
+                onChange={(e) => handleStickyLimitChange(e.target.value)}
+                placeholder="1"
+                className="w-12 rounded-lg border border-border bg-black/[0.02] px-1.5 py-0.5 text-xs text-text-primary outline-none dark:border-white/10 dark:bg-white/[0.03]"
+                title="Sticky limit (requests per account before rotating)"
+              />
+            )}
+          </div>
+          {providerId === "zenmux-free" && connections.length > 0 && (
+            <ZenmuxPlanSelector
+              connectionId={connections[0].id}
+              cookie={connections[0].apiKey || ""}
+              currentPlan={connections[0].providerSpecificData?.zenmuxPlan || "free"}
+              onPlanChanged={fetchConnections}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* ── Body ── */}
+      {connections.length === 0 ? (
+        // Empty state
+        <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+          <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <span className="material-symbols-outlined text-[24px]">{isOAuth ? "lock" : "key"}</span>
+          </div>
+          <div>
+            <p className="text-sm font-medium text-text-main">No connections yet</p>
+            {hasDualAuthModes && (
+              <p className="mt-0.5 text-xs text-text-muted">
+                Choose {oauthConnectionLabel} or {apiKeyConnectionLabel}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-wrap justify-center gap-2">
+            {hasDualAuthModes ? (
+              <>
+                <Button size="sm" icon="lock" variant="secondary" onClick={triggerOAuthConnection}>
+                  {oauthConnectionLabel}
+                </Button>
+                <Button size="sm" icon="key" onClick={triggerApiKeyConnection}>
+                  {apiKeyConnectionLabel}
+                </Button>
+              </>
+            ) : (
+              <>
+                {!isCompatible && providerId === "iflow" && (
+                  <Button size="sm" icon="cookie" variant="secondary" onClick={() => setShowIFlowCookieModal(true)}>
+                    Cookie
+                  </Button>
+                )}
+                {providerId === "codex" && (
+                  <Button size="sm" icon="playlist_add" variant="secondary" onClick={() => setShowBulkImportCodex(true)}>
+                    {translate("Bulk Add")}
+                  </Button>
+                )}
+                <Button size="sm" icon="add" onClick={triggerAddConnection}>
+                  {isCompatible ? "Add API Key" : (providerId === "iflow" ? "OAuth" : "Add Connection")}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      ) : (
+        // Populated state
+        <div className="flex flex-col">
+          {/* One-by-one test summary — progress bar style */}
+          {oneByOneSummary && (
+            <div className="border-b border-border-subtle px-4 py-2.5">
+              <div className="flex items-center gap-3 text-xs">
+                <div className="flex items-center gap-1.5">
+                  <span className="material-symbols-outlined text-[14px] text-text-muted">checklist</span>
+                  <span className="font-medium text-text-main">
+                    {oneByOneSummary.completed}/{oneByOneSummary.total}
+                  </span>
+                </div>
+                {oneByOneSummary.passed > 0 && (
+                  <span className="text-success">✓ {oneByOneSummary.passed}</span>
+                )}
+                {oneByOneSummary.failed > 0 && (
+                  <span className="text-danger">✗ {oneByOneSummary.failed}</span>
+                )}
+                {oneByOneSummary.stopped && (
+                  <span className="text-warning">Stopped</span>
+                )}
+                {oneByOneRunning && oneByOneCurrentConnectionId && (
+                  <span className="truncate text-text-muted">
+                    Testing: {connections.find((c) => c.id === oneByOneCurrentConnectionId)?.name || oneByOneCurrentConnectionId}
+                  </span>
+                )}
+              </div>
+              {/* Progress bar */}
+              {oneByOneSummary.total > 0 && (
+                <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-surface-2">
+                  <div
+                    className="h-full rounded-full bg-primary transition-all"
+                    style={{ width: `${(oneByOneSummary.completed / oneByOneSummary.total) * 100}%` }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Select All row */}
+          <div className="flex items-center gap-2 border-b border-border-subtle px-4 py-2">
+            <label className="flex cursor-pointer items-center gap-1.5 text-xs text-text-muted hover:text-primary">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                onChange={toggleSelectAllConnections}
+                className="h-3.5 w-3.5 rounded border-gray-300 text-primary focus:ring-primary"
+              />
+              Select All
+            </label>
+            {selectedConnectionIds.length > 0 && (
+              <span className="text-[10px] text-text-muted">
+                {selectedConnectionIds.length} selected
+              </span>
+            )}
+          </div>
+
+          {/* Connection rows */}
+          <div className="flex min-w-0 flex-col divide-y divide-border-subtle">
+            {connections.map((conn, index) => (
+              <div key={conn.id} className="flex min-w-0 items-stretch">
+                <div className="flex shrink-0 items-center pl-2 sm:pl-3">
+                  <input
+                    type="checkbox"
+                    checked={isSelected(conn.id)}
+                    onChange={() => toggleSelectConnection(conn.id)}
+                    className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <ConnectionRow
+                    connection={conn}
+                    proxyPools={proxyPools}
+                    isOAuth={isOAuth}
+                    isFirst={index === 0}
+                    isLast={index === connections.length - 1}
+                    onMoveUp={() => handleSwapPriority(index, index - 1)}
+                    onMoveDown={() => handleSwapPriority(index, index + 1)}
+                    onToggleActive={(isActive) => handleUpdateConnectionStatus(conn.id, isActive)}
+                    autoPing={
+                      AUTO_PING_SETTINGS_KEYS[providerId] && conn.authType === "oauth"
+                        ? {
+                            on: autoPing.connections[conn.id] === true,
+                            onToggle: (on) => handleAutoPingConnection(conn.id, on),
+                            provider: providerId,
+                          }
+                        : null
+                    }
+                    onUpdateProxy={async (proxyPoolId) => {
+                      try {
+                        const res = await fetch(`/api/providers/${conn.id}`, {
+                          method: "PUT",
+                          headers: { "Content-Type": "application/json" },
+                          body: JSON.stringify({ proxyPoolId: proxyPoolId || null }),
+                        });
+                        if (res.ok) {
+                          setConnections((prev) =>
+                            prev.map((c) =>
+                              c.id === conn.id
+                                ? { ...c, providerSpecificData: { ...c.providerSpecificData, proxyPoolId: proxyPoolId || null } }
+                                : c,
+                            ),
+                          );
+                        }
+                      } catch (error) {
+                        console.log("Error updating proxy:", error);
+                      }
+                    }}
+                    onEdit={() => {
+                      setSelectedConnection(conn);
+                      setShowEditModal(true);
+                    }}
+                    onDelete={() => handleDelete(conn.id)}
+                    oneByOneStatus={oneByOneResults[conn.id] || null}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Footer: add-connection buttons */}
+          {!isCompatible && (
+            <div className="flex flex-wrap items-center gap-2 border-t border-border-subtle px-4 py-3">
+              {providerId === "iflow" && (
+                <Button size="sm" icon="cookie" variant="secondary" onClick={() => setShowIFlowCookieModal(true)}>
+                  Cookie
+                </Button>
+              )}
+              {providerId === "codex" && (
+                <Button size="sm" icon="playlist_add" variant="secondary" onClick={() => setShowBulkImportCodex(true)}>
+                  {translate("Bulk Add")}
+                </Button>
+              )}
+              {hasDualAuthModes ? (
+                <>
+                  <Button size="sm" icon="lock" variant="secondary" onClick={triggerOAuthConnection}>
+                    {oauthConnectionLabel}
+                  </Button>
+                  <Button size="sm" icon="key" onClick={triggerApiKeyConnection}>
+                    {apiKeyConnectionLabel}
+                  </Button>
+                </>
+              ) : (
+                <Button size="sm" icon="add" onClick={triggerAddConnection}>
+                  Add
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Bulk proxy modal ── */}
+      <Modal
+        isOpen={showBulkProxyModal}
+        onClose={closeBulkProxyModal}
+        title={`Apply Proxy (${connections.length} connections)`}
+      >
+        <div className="flex flex-col gap-3">
+          {selectedProxySummary && (
+            <p className="text-xs text-text-muted">{selectedProxySummary}</p>
+          )}
+          <div className="flex flex-col">
+            <button
+              onClick={handleApplyOneToOne}
+              disabled={bulkUpdatingProxy || activePools.length === 0}
+              className="flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="material-symbols-outlined text-[18px] text-text-muted">sync_alt</span>
+              <span className="text-sm text-text-main">One-to-one (rotate)</span>
+            </button>
+            <button
+              onClick={() => handleApplySinglePool(null)}
+              disabled={bulkUpdatingProxy}
+              className="flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="material-symbols-outlined text-[18px] text-text-muted">link_off</span>
+              <span className="text-sm text-text-main">None (unbind all)</span>
+            </button>
+            {proxyPools.map((pool) => (
+              <button
+                key={pool.id}
+                onClick={() => handleApplySinglePool(pool.id)}
+                disabled={bulkUpdatingProxy || pool.isActive !== true}
+                className="flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span className="material-symbols-outlined text-[18px] text-text-muted">lan</span>
+                <span className="truncate text-sm text-text-main">{pool.name}</span>
+                {pool.isActive !== true && (
+                  <span className="text-[10px] text-text-muted">(inactive)</span>
+                )}
+              </button>
+            ))}
+          </div>
+          {bulkUpdatingProxy && <p className="text-xs text-text-muted">Applying...</p>}
+          <Button onClick={closeBulkProxyModal} variant="ghost" fullWidth disabled={bulkUpdatingProxy}>
+            Cancel
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelsCard.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelsCard.js
@@ -1,0 +1,307 @@
+"use client";
+
+import { Button, Input } from "@/shared/components";
+import { translate } from "@/i18n/runtime";
+import ModelRow from "../ModelRow";
+import CompatibleModelsSection from "../CompatibleModelsSection";
+import { getModelKind } from "@/shared/constants/models";
+import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
+
+/**
+ * Models card — extracted from page.js lines 1652-1712 (toolbar + card) +
+ * renderModelsSection() function (1031-1212). All state/handlers passed from
+ * page.js. Visual polish: responsive grid instead of flex-wrap, compact pill
+ * toolbar buttons, right-aligned search.
+ *
+ * Behavioral logic is UNCHANGED — pure extraction + restyle.
+ */
+export default function ModelsCard({
+  // identity
+  providerId,
+  isCompatible,
+  isAnthropicCompatible,
+  isFreeNoAuth,
+  providerStorageAlias,
+  providerDisplayAlias,
+
+  // data
+  models,
+  kiloFreeModels,
+  modelAliases,
+  customModels,
+  disabledModelIds,
+  modelTestResults,
+  testingModelIds,
+  testingAllModels,
+  modelsTestError,
+  modelSearchQuery,
+  connections,
+  suggestedModels,
+  importingQoderModels,
+  copied,
+
+  // hooks
+  getCaps,
+
+  // handlers
+  copy,
+  handleTestModel,
+  handleTestAllModels,
+  handleDisableModel,
+  handleEnableModel,
+  handleDisableAll,
+  handleEnableAll,
+  handleSetAlias,
+  handleDeleteAlias,
+  handleAddCustomModel,
+  handleDeleteCustomModel,
+  handleImportQoderModels,
+  setModelSearchQuery,
+  setShowAddCustomModel,
+}) {
+  // ── Compatible providers: delegate to CompatibleModelsSection ──
+  if (isCompatible) {
+    return (
+      <div className="px-4 py-3">
+        <CompatibleModelsSection
+          providerStorageAlias={providerStorageAlias}
+          providerDisplayAlias={providerDisplayAlias}
+          modelAliases={modelAliases}
+          customModels={customModels}
+          copied={copied}
+          onCopy={copy}
+          onSetAlias={handleSetAlias}
+          onDeleteAlias={handleDeleteAlias}
+          onAddCustomModel={(modelId) => handleAddCustomModel(modelId, "llm", providerStorageAlias)}
+          onDeleteCustomModel={(modelId) => handleDeleteCustomModel(modelId, "llm", providerStorageAlias)}
+          connections={connections}
+          isAnthropic={isAnthropicCompatible}
+        />
+      </div>
+    );
+  }
+
+  // ── Standard providers: model grid ──
+  // Combine hardcoded models with Kilo free models (deduplicated), exclude non-llm.
+  const allModels = [
+    ...models,
+    ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
+  ].filter((m) => { const k = getModelKind(m); return !k || k === "llm"; });
+
+  const disabledSet = new Set(disabledModelIds);
+  const displayModels = allModels.filter((m) => !disabledSet.has(m.id));
+  const disabledDisplayModels = allModels.filter((m) => disabledSet.has(m.id));
+  const customModelRows = getProviderCustomModelRows({
+    customModels,
+    modelAliases,
+    providerAlias: providerStorageAlias,
+    builtInModels: models,
+    type: "llm",
+  });
+
+  // Search filter
+  const q = modelSearchQuery.trim().toLowerCase();
+  const matchesSearch = (id, name = "") =>
+    !q || id.toLowerCase().includes(q) || String(name).toLowerCase().includes(q);
+  const filteredDisplayModels = displayModels.filter((m) => matchesSearch(m.id, m.name));
+  const filteredCustomModelRows = customModelRows.filter((m) => matchesSearch(m.id, m.name));
+
+  // Toolbar IDs
+  const allIds = allModels.map((m) => m.id);
+  const activeIds = allIds.filter((id) => !disabledModelIds.includes(id));
+  const testableIds = activeIds.filter((id) => !q || id.toLowerCase().includes(q));
+
+  return (
+    <div className="flex flex-col">
+      {/* ── Toolbar ── */}
+      <div className="flex flex-col gap-2 border-b border-border-subtle px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-1.5">
+          {disabledModelIds.length > 0 && (
+            <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll}>
+              Active All
+            </Button>
+          )}
+          {activeIds.length > 0 && (
+            <Button size="sm" variant="secondary" icon="block" onClick={() => handleDisableAll(activeIds)}>
+              Disable All
+            </Button>
+          )}
+          {(connections.length > 0 || isFreeNoAuth) && testableIds.length > 0 && (
+            <Button
+              size="sm"
+              variant="primary"
+              icon={testingAllModels ? "progress_activity" : "play_arrow"}
+              onClick={() => handleTestAllModels(testableIds)}
+              disabled={testingAllModels}
+              className={testingAllModels ? "animate-pulse" : ""}
+            >
+              {testingAllModels ? "Testing..." : `Test All (${testableIds.length})`}
+            </Button>
+          )}
+        </div>
+        <div className="sm:w-56">
+          <Input
+            type="search"
+            placeholder="Search models..."
+            value={modelSearchQuery}
+            onChange={(e) => setModelSearchQuery(e.target.value)}
+            className="w-full"
+          />
+        </div>
+      </div>
+
+      {/* ── Body ── */}
+      <div className="px-4 py-3">
+        {!!modelsTestError && (
+          <p className="mb-3 break-words text-xs text-danger">{modelsTestError}</p>
+        )}
+
+        {/* Model grid — responsive instead of flex-wrap */}
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {/* Custom models first */}
+          {filteredCustomModelRows.map((model) => (
+            <ModelRow
+              key={`${model.source}-${model.fullModel}`}
+              model={{ id: model.id, name: model.name }}
+              fullModel={`${providerDisplayAlias}/${model.id}`}
+              alias={model.alias}
+              copied={copied}
+              onCopy={copy}
+              onSetAlias={() => {}}
+              onDeleteAlias={() => {
+                if (model.source === "custom") {
+                  handleDeleteCustomModel(model.id, "llm", providerStorageAlias);
+                } else {
+                  handleDeleteAlias(model.alias);
+                }
+              }}
+              testStatus={modelTestResults[model.id]}
+              onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
+              isTesting={testingModelIds.has(model.id)}
+              isCustom
+              isFree={false}
+              caps={getCaps(`${providerId}/${model.id}`)}
+            />
+          ))}
+
+          {/* Built-in display models */}
+          {filteredDisplayModels.map((model) => {
+            const fullModel = `${providerStorageAlias}/${model.id}`;
+            const oldFormatModel = `${providerId}/${model.id}`;
+            const existingAlias = Object.entries(modelAliases).find(
+              ([, m]) => m === fullModel || m === oldFormatModel,
+            )?.[0];
+            return (
+              <ModelRow
+                key={model.id}
+                model={model}
+                fullModel={`${providerDisplayAlias}/${model.id}`}
+                alias={existingAlias}
+                copied={copied}
+                onCopy={copy}
+                onSetAlias={(alias) => handleSetAlias(model.id, alias, providerStorageAlias)}
+                onDeleteAlias={() => handleDeleteAlias(existingAlias)}
+                testStatus={modelTestResults[model.id]}
+                onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
+                isTesting={testingModelIds.has(model.id)}
+                isFree={model.isFree}
+                onDisable={() => handleDisableModel(model.id)}
+                caps={getCaps(`${providerId}/${model.id}`)}
+              />
+            );
+          })}
+        </div>
+
+        {/* No search results */}
+        {modelSearchQuery.trim() && filteredDisplayModels.length === 0 && filteredCustomModelRows.length === 0 && (
+          <p className="w-full py-4 text-center text-sm text-text-muted">
+            No models match &ldquo;{modelSearchQuery}&rdquo;
+          </p>
+        )}
+
+        {/* Add model + Qoder import buttons */}
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            onClick={() => setShowAddCustomModel(true)}
+            className="flex items-center gap-1.5 rounded-lg border border-dashed border-primary/40 px-3 py-2 text-xs text-primary transition-colors hover:border-primary hover:bg-primary/5"
+          >
+            <span className="material-symbols-outlined text-sm">add</span>
+            Add Model
+          </button>
+          {providerId === "qoder" && connections.some((conn) => conn.isActive !== false) && (
+            <button
+              onClick={handleImportQoderModels}
+              disabled={importingQoderModels}
+              className="flex items-center gap-1.5 rounded-lg border border-dashed border-blue-500/40 px-3 py-2 text-xs text-info transition-colors hover:border-blue-500 hover:bg-blue-500/5 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span
+                className="material-symbols-outlined text-sm"
+                style={importingQoderModels ? { animation: "spin 1s linear infinite" } : undefined}
+              >
+                {importingQoderModels ? "progress_activity" : "download"}
+              </span>
+              {importingQoderModels ? translate("Fetching...") : translate("Fetch Qoder Models")}
+            </button>
+          )}
+        </div>
+
+        {/* Suggested models */}
+        {suggestedModels.length > 0 && (() => {
+          const addedFullModels = new Set([
+            ...Object.values(modelAliases),
+            ...customModelRows.map((model) => model.fullModel),
+          ]);
+          const hardcodedIds = new Set(models.map((m) => m.id));
+          const notAdded = suggestedModels.filter(
+            (m) => !addedFullModels.has(`${providerStorageAlias}/${m.id}`) && !hardcodedIds.has(m.id),
+          );
+          if (notAdded.length === 0) return null;
+          return (
+            <div className="mt-3 w-full">
+              <p className="mb-2 text-[10px] uppercase tracking-wide text-text-muted">
+                Suggested free models
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {notAdded.map((m) => (
+                  <button
+                    key={m.id}
+                    onClick={async () => {
+                      await handleAddCustomModel(m.id, "llm", providerStorageAlias);
+                    }}
+                    className="flex items-center gap-1 rounded-lg border border-border px-2.5 py-1.5 text-xs text-text-muted transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+                    title={`${m.name} · ${(m.contextLength / 1000).toFixed(0)}k ctx`}
+                  >
+                    <span className="material-symbols-outlined text-[13px]">add</span>
+                    {m.id.split("/").pop()}
+                  </button>
+                ))}
+              </div>
+            </div>
+          );
+        })()}
+
+        {/* Disabled models — restorable */}
+        {disabledDisplayModels.length > 0 && (
+          <div className="mt-3 w-full">
+            <p className="mb-2 text-[10px] uppercase tracking-wide text-text-muted">
+              Disabled ({disabledDisplayModels.length})
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {disabledDisplayModels.map((m) => (
+                <button
+                  key={m.id}
+                  onClick={() => handleEnableModel(m.id)}
+                  className="flex items-center gap-1 rounded-lg border border-dashed border-border px-2.5 py-1.5 text-xs text-text-muted transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+                  title="Restore model"
+                >
+                  <span className="material-symbols-outlined text-[13px]">add</span>
+                  {m.id}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderDetailHeader.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderDetailHeader.js
@@ -1,0 +1,164 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { Badge } from "@/shared/components";
+import { cn } from "@/shared/utils/cn";
+
+/**
+ * Branded header for the provider detail page — replaces the old plain icon
+ * box. Larger icon (size-14 tinted chip, matching the Providers list tile
+ * style), name + category/connection/model summary line, external links, and
+ * deprecation/info banners.
+ *
+ * Extracted from page.js lines 1238-1324. Behavioral logic unchanged.
+ */
+export default function ProviderDetailHeader({
+  providerInfo,
+  providerId,
+  connections,
+  modelCount,
+  headerIconPath,
+  headerImgError,
+  setHeaderImgError,
+}) {
+  const externalUrl =
+    providerInfo.notice?.apiKeyUrl ||
+    providerInfo.notice?.signupUrl ||
+    providerInfo.website;
+
+  // Category badge label derived from authModes/authType.
+  const categoryLabel = providerInfo.authModes
+    ? providerInfo.authModes.includes("oauth") && providerInfo.authModes.includes("apikey")
+      ? "OAuth + API Key"
+      : providerInfo.authModes[0] === "oauth"
+        ? "OAuth"
+        : providerInfo.authModes[0] === "cookie"
+          ? "Cookie"
+          : "API Key"
+    : providerInfo.authType === "oauth"
+      ? "OAuth"
+      : providerInfo.authType === "cookie"
+        ? "Cookie"
+        : "API Key";
+
+  // Summary chips: category · N connections · N models
+  const summaryParts = [categoryLabel];
+  if (connections.length > 0) {
+    summaryParts.push(`${connections.length} connection${connections.length === 1 ? "" : "s"}`);
+  }
+  if (modelCount > 0) {
+    summaryParts.push(`${modelCount} model${modelCount === 1 ? "" : "s"}`);
+  }
+
+  const color = providerInfo.color || "#6366f1";
+
+  return (
+    <div className="min-w-0">
+      <Link
+        href="/dashboard/providers"
+        className="inline-flex items-center gap-1 text-sm text-text-muted transition-colors hover:text-primary"
+      >
+        <span className="material-symbols-outlined text-lg">arrow_back</span>
+        Back to Providers
+      </Link>
+
+      {/* Branded icon + name row */}
+      <div className="mt-4 flex min-w-0 items-center gap-4">
+        <div
+          className="flex size-14 shrink-0 items-center justify-center rounded-xl"
+          style={{ backgroundColor: `${color}15` }}
+        >
+          {headerImgError ? (
+            <span
+              className="text-base font-bold"
+              style={{ color }}
+            >
+              {providerInfo.textIcon || providerInfo.id?.slice(0, 2).toUpperCase()}
+            </span>
+          ) : (
+            <Image
+              src={headerIconPath}
+              alt={providerInfo.name}
+              width={48}
+              height={48}
+              className="max-h-12 max-w-12 rounded-lg object-contain"
+              sizes="48px"
+              onError={() => setHeaderImgError(true)}
+            />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="truncate text-2xl font-semibold tracking-tight text-text-main">
+              {providerInfo.name}
+            </h1>
+            {externalUrl && (
+              <a
+                href={externalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <span className="material-symbols-outlined text-sm">open_in_new</span>
+                {providerInfo.notice?.apiKeyUrl ? "Get API Key" : "Sign up"}
+              </a>
+            )}
+            {providerId === "moonshot" && (
+              <a
+                href="https://www.kimi.com/activities/viral-referral/share?scenario=invite&from=share_poster&invitation_code=BPGXZR"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 rounded-full bg-primary/12 px-3 py-1 text-xs font-semibold text-primary ring-1 ring-primary/20 transition-colors hover:bg-primary/20"
+              >
+                <span className="material-symbols-outlined text-sm">celebration</span>
+                Get KIMI K3 For Free
+              </a>
+            )}
+          </div>
+          {/* Summary line: category · connections · models */}
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+            {summaryParts.map((part, i) => (
+              <span key={i} className="inline-flex items-center gap-2">
+                {i > 0 && <span className="text-text-muted/40">·</span>}
+                {part}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Deprecation banner */}
+      {providerInfo.deprecated && (
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2">
+          <span className="material-symbols-outlined mt-0.5 shrink-0 text-[16px] text-yellow-500">
+            warning
+          </span>
+          <p className="text-xs leading-relaxed text-red-600 dark:text-yellow-400">
+            {providerInfo.deprecationNotice}
+          </p>
+        </div>
+      )}
+
+      {/* Info notice banner */}
+      {providerInfo.notice?.text && !providerInfo.deprecated && (
+        <div className="mt-4 flex flex-col gap-2 rounded-lg border border-info/30 bg-info/10 px-3 py-2 sm:flex-row sm:items-center">
+          <span className="material-symbols-outlined shrink-0 text-[16px] text-info">info</span>
+          <p className="min-w-0 flex-1 text-xs leading-relaxed text-info">
+            {providerInfo.notice.text}
+          </p>
+          {providerInfo.notice.apiKeyUrl && (
+            <a
+              href={providerInfo.notice.apiKeyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex justify-center rounded bg-blue-500 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-blue-600 sm:py-0.5"
+            >
+              Get API Key →
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -2,31 +2,25 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
-import Link from "next/link";
-import Image from "next/image";
-import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal } from "@/shared/components";
+import { Card, Button, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, EditConnectionModal, ConfirmModal } from "@/shared/components";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS, THINKING_CONFIG } from "@/shared/constants/providers";
-import { getModelsByProviderId, getModelKind } from "@/shared/constants/models";
+import { getModelsByProviderId } from "@/shared/constants/models";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { useModelCaps } from "@/shared/hooks/useModelCaps";
 import { translate } from "@/i18n/runtime";
 import { fetchSuggestedModels } from "@/shared/utils/providerModelsFetcher";
-import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
 import { getProviderIconPath } from "@/shared/utils/providerIcon";
-import ModelRow from "./ModelRow";
-import CompatibleModelsSection from "./CompatibleModelsSection";
-import ConnectionRow from "./ConnectionRow";
 import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
 import BulkImportCodexModal from "./BulkImportCodexModal";
-import VaultPoolBadge from "./VaultPoolBadge";
-import ZenmuxPlanSelector from "./ZenmuxPlanSelector";
 import HealthTimeline from "./HealthTimeline";
-import FreeBuffProfile from "./FreeBuffProfile";
-import V0Profile from "./V0Profile";
-import QwenCloudProfile from "./QwenCloudProfile";
 import { useNewBadge } from "@/shared/hooks/useNewBadge";
+// Extracted section components (redesign)
+import ProviderDetailHeader from "./components/ProviderDetailHeader";
+import CollapsibleSection from "./components/CollapsibleSection";
+import ConnectionsCard from "./components/ConnectionsCard";
+import ModelsCard from "./components/ModelsCard";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
@@ -887,117 +881,12 @@ export default function ProviderDetailPage() {
   };
 
 
-  const isSelected = (connectionId) => selectedConnectionIds.includes(connectionId);
-
-  const connectionsList = (
-    <div className="flex min-w-0 flex-col divide-y divide-border-subtle">
-      {connections
-        .map((conn, index) => (
-          <div key={conn.id} className="flex min-w-0 items-stretch">
-            <div className="flex shrink-0 items-center pl-1 sm:pl-2">
-              <input
-                type="checkbox"
-                checked={isSelected(conn.id)}
-                onChange={() => toggleSelectConnection(conn.id)}
-                className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
-              />
-            </div>
-            <div className="flex-1 min-w-0">
-              <ConnectionRow
-                connection={conn}
-                proxyPools={proxyPools}
-                isOAuth={isOAuth}
-                isFirst={index === 0}
-                isLast={index === connections.length - 1}
-                onMoveUp={() => handleSwapPriority(index, index - 1)}
-                onMoveDown={() => handleSwapPriority(index, index + 1)}
-                onToggleActive={(isActive) => handleUpdateConnectionStatus(conn.id, isActive)}
-                autoPing={AUTO_PING_SETTINGS_KEYS[providerId] && conn.authType === "oauth" ? {
-                  on: autoPing.connections[conn.id] === true,
-                  onToggle: (on) => handleAutoPingConnection(conn.id, on),
-                  provider: providerId,
-                } : null}
-                onUpdateProxy={async (proxyPoolId) => {
-                  try {
-                    const res = await fetch(`/api/providers/${conn.id}`, {
-                      method: "PUT",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ proxyPoolId: proxyPoolId || null }),
-                    });
-                    if (res.ok) {
-                      setConnections(prev => prev.map(c =>
-                        c.id === conn.id
-                          ? { ...c, providerSpecificData: { ...c.providerSpecificData, proxyPoolId: proxyPoolId || null } }
-                          : c
-                      ));
-                    }
-                  } catch (error) {
-                    console.log("Error updating proxy:", error);
-                  }
-                }}
-                onEdit={() => {
-                  setSelectedConnection(conn);
-                  setShowEditModal(true);
-                }}
-                onDelete={() => handleDelete(conn.id)}
-                oneByOneStatus={oneByOneResults[conn.id] || null}
-              />
-            </div>
-          </div>
-        ))}
-    </div>
-  );
+  // NOTE: connectionsList, activePools, and bulkActionModal were extracted
+  // into ConnectionsCard.js during the page redesign. The handlers above
+  // (applyProxyAssignments, handleApplySinglePool, handleApplyOneToOne, etc.)
+  // remain here and are passed as props to ConnectionsCard.
 
   const activePools = proxyPools.filter((p) => p.isActive === true);
-
-  const bulkActionModal = (
-    <Modal
-      isOpen={showBulkProxyModal}
-      onClose={closeBulkProxyModal}
-      title={`Apply Proxy (${connections.length} connections)`}
-    >
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col">
-          <button
-            onClick={handleApplyOneToOne}
-            disabled={bulkUpdatingProxy || activePools.length === 0}
-            className="flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <span className="material-symbols-outlined text-text-muted text-[18px]">sync_alt</span>
-            <span className="text-sm text-text-main">One-to-one (rotate)</span>
-          </button>
-          <button
-            onClick={() => handleApplySinglePool(null)}
-            disabled={bulkUpdatingProxy}
-            className="flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <span className="material-symbols-outlined text-text-muted text-[18px]">link_off</span>
-            <span className="text-sm text-text-main">None (unbind all)</span>
-          </button>
-          {proxyPools.map((pool) => (
-            <button
-              key={pool.id}
-              onClick={() => handleApplySinglePool(pool.id)}
-              disabled={bulkUpdatingProxy || pool.isActive !== true}
-              className="flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <span className="material-symbols-outlined text-text-muted text-[18px]">lan</span>
-              <span className="truncate text-sm text-text-main">{pool.name}</span>
-              {pool.isActive !== true && (
-                <span className="text-[10px] text-text-muted">(inactive)</span>
-              )}
-            </button>
-          ))}
-        </div>
-
-        {bulkUpdatingProxy && <p className="text-xs text-text-muted">Applying...</p>}
-
-        <Button onClick={closeBulkProxyModal} variant="ghost" fullWidth disabled={bulkUpdatingProxy}>
-          Cancel
-        </Button>
-      </div>
-    </Modal>
-  );
 
   const handleTestModel = async (modelId) => {
     if (testingModelIds.has(modelId)) return;
@@ -1028,306 +917,55 @@ export default function ProviderDetailPage() {
     setTestingAllModels(false);
   };
 
-  const renderModelsSection = () => {
-    if (isCompatible) {
-      return (
-        <CompatibleModelsSection
-          providerStorageAlias={providerStorageAlias}
-          providerDisplayAlias={providerDisplayAlias}
-          modelAliases={modelAliases}
-          customModels={customModels}
-          copied={copied}
-          onCopy={copy}
-          onSetAlias={handleSetAlias}
-          onDeleteAlias={handleDeleteAlias}
-          onAddCustomModel={(modelId) => handleAddCustomModel(modelId, "llm", providerStorageAlias)}
-          onDeleteCustomModel={(modelId) => handleDeleteCustomModel(modelId, "llm", providerStorageAlias)}
-          connections={connections}
-          isAnthropic={isAnthropicCompatible}
-        />
-      );
-    }
-    // Combine hardcoded models with Kilo free models (deduplicated)
-    // Exclude non-llm models (embedding, tts, etc.) — they have dedicated pages under media-providers
-    const allModels = [
-      ...models,
-      ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
-    ].filter((m) => { const k = getModelKind(m); return !k || k === "llm"; });
-    const disabledSet = new Set(disabledModelIds);
-    const displayModels = allModels.filter((m) => !disabledSet.has(m.id));
-    const disabledDisplayModels = allModels.filter((m) => disabledSet.has(m.id));
-    const customModelRows = getProviderCustomModelRows({
-      customModels,
-      modelAliases,
-      providerAlias: providerStorageAlias,
-      builtInModels: models,
-      type: "llm",
-    });
+  // NOTE: connectionsList, bulkActionModal, and renderModelsSection were
+  // extracted into ConnectionsCard.js and ModelsCard.js during the redesign.
+  // All handlers above remain here and are passed as props.
 
-    // Apply the search filter (match against model id, name, and full alias path).
-    const q = modelSearchQuery.trim().toLowerCase();
-    const matchesSearch = (id, name = "") =>
-      !q || id.toLowerCase().includes(q) || String(name).toLowerCase().includes(q);
-    const filteredDisplayModels = displayModels.filter((m) => matchesSearch(m.id, m.name));
-    const filteredCustomModelRows = customModelRows.filter((m) => matchesSearch(m.id, m.name));
-
-    return (
-      <div className="flex flex-wrap gap-3">
-        {/* Custom models first */}
-        {filteredCustomModelRows.map((model) => (
-          <ModelRow
-            key={`${model.source}-${model.fullModel}`}
-            model={{ id: model.id, name: model.name }}
-            fullModel={`${providerDisplayAlias}/${model.id}`}
-            alias={model.alias}
-            copied={copied}
-            onCopy={copy}
-            onSetAlias={() => {}}
-            onDeleteAlias={() => {
-              if (model.source === "custom") {
-                handleDeleteCustomModel(model.id, "llm", providerStorageAlias);
-              } else {
-                handleDeleteAlias(model.alias);
-              }
-            }}
-            testStatus={modelTestResults[model.id]}
-            onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
-            isTesting={testingModelIds.has(model.id)}
-            isCustom
-            isFree={false}
-            caps={getCaps(`${providerId}/${model.id}`)}
-          />
-        ))}
-
-        {filteredDisplayModels.map((model) => {
-          const fullModel = `${providerStorageAlias}/${model.id}`;
-          const oldFormatModel = `${providerId}/${model.id}`;
-          const existingAlias = Object.entries(modelAliases).find(
-            ([, m]) => m === fullModel || m === oldFormatModel
-          )?.[0];
-          return (
-            <ModelRow
-              key={model.id}
-              model={model}
-              fullModel={`${providerDisplayAlias}/${model.id}`}
-              alias={existingAlias}
-              copied={copied}
-              onCopy={copy}
-              onSetAlias={(alias) => handleSetAlias(model.id, alias, providerStorageAlias)}
-              onDeleteAlias={() => handleDeleteAlias(existingAlias)}
-              testStatus={modelTestResults[model.id]}
-              onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
-              isTesting={testingModelIds.has(model.id)}
-              isFree={model.isFree}
-              onDisable={() => handleDisableModel(model.id)}
-              caps={getCaps(`${providerId}/${model.id}`)}
-            />
-          );
-        })}
-
-        {/* No search results */}
-        {modelSearchQuery.trim() && filteredDisplayModels.length === 0 && filteredCustomModelRows.length === 0 && (
-          <p className="w-full text-center text-sm text-text-muted py-4">
-            No models match &ldquo;{modelSearchQuery}&rdquo;
-          </p>
-        )}
-
-        {/* Add model button — inline, same style as model chips */}
-        <button
-          onClick={() => setShowAddCustomModel(true)}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-primary/40 px-3 py-2 text-xs text-primary transition-colors hover:border-primary hover:bg-primary/5 sm:w-auto"
-        >
-          <span className="material-symbols-outlined text-sm">add</span>
-          Add Model
-        </button>
-
-        {/* Import Qoder models button — only show for qoder provider */}
-        {providerId === "qoder" && connections.some((conn) => conn.isActive !== false) && (
-          <button
-            onClick={handleImportQoderModels}
-            disabled={importingQoderModels}
-            className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-blue-500/40 px-3 py-2 text-xs text-info transition-colors hover:border-blue-500 hover:bg-blue-500/5 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <span className="material-symbols-outlined text-sm" style={importingQoderModels ? { animation: "spin 1s linear infinite" } : undefined}>
-              {importingQoderModels ? "progress_activity" : "download"}
-            </span>
-            {importingQoderModels ? translate("Fetching...") : translate("Fetch Qoder Models")}
-          </button>
-        )}
-
-        {/* Suggested models from provider API — show only models not yet added */}
-        {suggestedModels.length > 0 && (() => {
-          const addedFullModels = new Set([
-            ...Object.values(modelAliases),
-            ...customModelRows.map((model) => model.fullModel),
-          ]);
-          const hardcodedIds = new Set(models.map((m) => m.id));
-          const notAdded = suggestedModels.filter(
-            (m) => !addedFullModels.has(`${providerStorageAlias}/${m.id}`) && !hardcodedIds.has(m.id)
-          );
-          if (notAdded.length === 0) return null;
-          return (
-            <div className="w-full mt-2">
-              <p className="text-xs text-text-muted mb-2">Suggested free models (≥200k context):</p>
-              <div className="flex flex-wrap gap-2">
-                {notAdded.map((m) => (
-                  <button
-                    key={m.id}
-                    onClick={async () => {
-                      await handleAddCustomModel(m.id, "llm", providerStorageAlias);
-                    }}
-                    className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-border text-xs text-text-muted hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors"
-                    title={`${m.name} · ${(m.contextLength / 1000).toFixed(0)}k ctx`}
-                  >
-                    <span className="material-symbols-outlined text-[13px]">add</span>
-                    {m.id.split("/").pop()}
-                  </button>
-                ))}
-              </div>
-            </div>
-          );
-        })()}
-
-        {/* Disabled models — restorable */}
-        {disabledDisplayModels.length > 0 && (
-          <div className="w-full mt-2">
-            <p className="text-xs text-text-muted mb-2">Disabled models ({disabledDisplayModels.length}):</p>
-            <div className="flex flex-wrap gap-2">
-              {disabledDisplayModels.map((m) => (
-                <button
-                  key={m.id}
-                  onClick={() => handleEnableModel(m.id)}
-                  className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-dashed border-border text-xs text-text-muted hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors"
-                  title="Restore model"
-                >
-                  <span className="material-symbols-outlined text-[13px]">add</span>
-                  {m.id}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    );
-  };
+  // ── Early returns ──────────────────────────────────────────────────────
 
   if (loading) {
     return (
-      <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-6">
         <CardSkeleton />
         <CardSkeleton />
       </div>
     );
-}
+  }
 
   if (!providerInfo) {
     return (
-      <div className="text-center py-20">
+      <div className="py-20 text-center">
         <p className="text-text-muted">Provider not found</p>
-        <Link href="/dashboard/providers" className="text-primary mt-4 inline-block">
+        <Link href="/dashboard/providers" className="mt-4 inline-block text-primary">
           Back to Providers
         </Link>
       </div>
     );
   }
 
-  // Resolve the provider icon asset path (handles compatible prefixes + SVG/PNG).
   const headerIconPath = getProviderIconPath(providerInfo.id, providerInfo.apiType);
 
+  // ── Main render ────────────────────────────────────────────────────────
+
   return (
-    <div className="flex min-w-0 flex-col gap-6">
-      {/* Header */}
-      <div className="min-w-0">
-        <Link
-          href="/dashboard/providers"
-          className="inline-flex items-center gap-1 text-sm text-text-muted hover:text-primary transition-colors mb-4"
-        >
-          <span className="material-symbols-outlined text-lg">arrow_back</span>
-          Back to Providers
-        </Link>
-        <div className="flex min-w-0 items-center gap-3 sm:gap-4">
-          <div
-            className="flex size-12 shrink-0 items-center justify-center rounded-lg"
-            style={{ backgroundColor: `${providerInfo.color}15` }}
-          >
-            {headerImgError ? (
-              <span className="text-sm font-bold" style={{ color: providerInfo.color }}>
-                {providerInfo.textIcon || providerInfo.id.slice(0, 2).toUpperCase()}
-              </span>
-            ) : (
-              <Image
-                src={headerIconPath}
-                alt={providerInfo.name}
-                width={48}
-                height={48}
-                className="max-h-12 max-w-12 rounded-lg object-contain"
-                sizes="48px"
-                onError={() => setHeaderImgError(true)}
-              />
-            )}
-          </div>
-          <div className="min-w-0">
-            <div className="flex items-center gap-3 flex-wrap">
-              <h1 className="truncate text-2xl font-semibold tracking-tight sm:text-3xl">{providerInfo.name}</h1>
-              {(providerInfo.notice?.apiKeyUrl || providerInfo.notice?.signupUrl || providerInfo.website) && (
-                <a
-                  href={providerInfo.notice?.apiKeyUrl || providerInfo.notice?.signupUrl || providerInfo.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs text-primary hover:underline inline-flex items-center gap-1"
-                >
-                  <span className="material-symbols-outlined text-sm">open_in_new</span>
-                  {providerInfo.notice?.apiKeyUrl ? "Get API Key" : "Sign up / Learn more"}
-                </a>
-              )}
-              {providerId === "moonshot" && (
-                <a
-                  href="https://www.kimi.com/activities/viral-referral/share?scenario=invite&from=share_poster&invitation_code=BPGXZR"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 rounded-full bg-primary/12 px-3 py-1 text-xs font-semibold text-primary ring-1 ring-primary/20 hover:bg-primary/20 transition-colors"
-                >
-                  <span className="material-symbols-outlined text-sm">celebration</span>
-                  Get KIMI K3 For Free
-                </a>
-              )}
-            </div>
-            <p className="text-text-muted">
-              {connections.length} connection{connections.length === 1 ? "" : "s"}
-            </p>
-          </div>
-        </div>
-      </div>
+    <div className="flex min-w-0 flex-col gap-5">
+      {/* Branded header */}
+      <ProviderDetailHeader
+        providerInfo={providerInfo}
+        providerId={providerId}
+        connections={connections}
+        modelCount={models.length}
+        headerIconPath={headerIconPath}
+        headerImgError={headerImgError}
+        setHeaderImgError={setHeaderImgError}
+      />
 
-      {providerInfo.deprecated && (
-        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
-          <span className="material-symbols-outlined text-[16px] text-yellow-500 mt-0.5 shrink-0">warning</span>
-          <p className="text-xs text-red-600 dark:text-yellow-400 leading-relaxed">{providerInfo.deprecationNotice}</p>
-        </div>
-      )}
-
-      {providerInfo.notice?.text && !providerInfo.deprecated && (
-        <div className="flex flex-col gap-2 rounded-lg border border-info/30 bg-info/10 px-3 py-2 sm:flex-row sm:items-center">
-          <span className="material-symbols-outlined text-[16px] text-info shrink-0">info</span>
-          <p className="min-w-0 flex-1 text-xs leading-relaxed text-info">{providerInfo.notice.text}</p>
-          {providerInfo.notice.apiKeyUrl && (
-            <a
-              href={providerInfo.notice.apiKeyUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex justify-center rounded bg-blue-500 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-blue-600 sm:py-0.5"
-            >
-              Get API Key →
-            </a>
-          )}
-        </div>
-      )}
-
+      {/* Compatible-node details (OpenAI/Anthropic compatible only) */}
       {isCompatible && providerNode && (
         <Card>
-          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold">{isAnthropicCompatible ? "Anthropic Compatible Details" : "OpenAI Compatible Details"}</h2>
+              <h2 className="text-lg font-semibold">{isAnthropicCompatible ? "Anthropic Compatible" : "OpenAI Compatible"}</h2>
               <p className="break-all text-sm text-text-muted">
                 {isAnthropicCompatible ? "Messages API" : (providerNode.apiType === "responses" ? "Responses API" : "Chat Completions")} · {(providerNode.baseUrl || "").replace(/\/$/, "")}/
                 {isAnthropicCompatible ? "messages" : (providerNode.apiType === "responses" ? "responses" : "chat/completions")}
@@ -1337,28 +975,19 @@ export default function ProviderDetailPage() {
               <Button
                 size="sm"
                 icon="add"
-                onClick={() => {
-                  setAddConnectionError("");
-                  setShowAddApiKeyModal(true);
-                }}
+                onClick={() => { setAddConnectionError(""); setShowAddApiKeyModal(true); }}
                 className="w-full sm:w-auto"
               >
                 Add API Key
               </Button>
-              <Button
-                size="sm"
-                variant="secondary"
-                icon="edit"
-                onClick={() => setShowEditNodeModal(true)}
-                className="w-full sm:w-auto"
-              >
+              <Button size="sm" variant="secondary" icon="edit" onClick={() => setShowEditNodeModal(true)} className="w-full sm:w-auto">
                 Edit
               </Button>
               <Button
                 size="sm"
                 variant="secondary"
                 icon="delete"
-                onClick={async () => {
+                onClick={() => {
                   setConfirmState({
                     title: "Delete Compatible Node",
                     message: `Delete this ${isAnthropicCompatible ? "Anthropic" : "OpenAI"} Compatible node?`,
@@ -1366,13 +995,11 @@ export default function ProviderDetailPage() {
                       setConfirmState(null);
                       try {
                         const res = await fetch(`/api/provider-nodes/${providerId}`, { method: "DELETE" });
-                        if (res.ok) {
-                          router.push("/dashboard/providers");
-                        }
+                        if (res.ok) router.push("/dashboard/providers");
                       } catch (error) {
                         console.log("Error deleting provider node:", error);
                       }
-                    }
+                    },
                   });
                 }}
                 className="w-full sm:w-auto"
@@ -1384,336 +1011,139 @@ export default function ProviderDetailPage() {
         </Card>
       )}
 
-      {/* Connections */}
-      {isFreeNoAuth ? (
-        <NoAuthProxyCard providerId={providerId} />
-      ) : (
-        <Card>
-          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold">Connections</h2>
-              <VaultPoolBadge providerId={providerId} />
-              {providerId === "freebuff-web" && connections.length > 0 && (
-                <FreeBuffProfile connectionId={connections[0].id} />
-              )}
-              {providerId === "v0-vercel-web" && connections.length > 0 && (
-                <V0Profile connectionId={connections[0].id} />
-              )}
-              {providerId === "qwencloud" && connections.length > 0 && (
-                <QwenCloudProfile connectionId={connections[0].id} />
-              )}
-            </div>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-              {connections.length > 0 && proxyPools.length > 0 && (
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  icon="lan"
-                  onClick={() => setShowBulkProxyModal(true)}
-                >
-                  Apply Proxy
-                </Button>
-              )}
-              {connections.length > 0 && (
-                <>
-                  {selectedConnectionIds.length > 0 && (
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      icon="delete"
-                      onClick={handleBulkDelete}
-                    >
-                      Delete Selected ({selectedConnectionIds.length})
-                    </Button>
-                  )}
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    icon="sync"
-                    onClick={handleRunOneByOneTest}
-                    disabled={oneByOneRunning}
-                  >
-                    {oneByOneRunning ? "Testing Connection One-by-One..." : "Test Connection One-by-One"}
-                  </Button>
-                  {oneByOneRunning && (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      icon="stop"
-                      onClick={handleStopOneByOneTest}
-                      disabled={oneByOneStopping}
-                    >
-                      {oneByOneStopping ? "Stopping..." : "Stop"}
-                    </Button>
-                  )}
-                </>
-              )}
-              {/* Thinking config */}
-              {thinkingConfig && (
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-text-muted font-medium">Thought Level</span>
-                  <select
-                    value={thinkingMode}
-                    onChange={(e) => handleThinkingModeChange(e.target.value)}
-                    className="text-xs px-2 py-1 border border-border rounded-md bg-background focus:outline-none focus:border-primary"
-                  >
-                    {thinkingConfig.options.map((opt) => (
-                      <option key={opt} value={opt}>{opt.charAt(0).toUpperCase() + opt.slice(1)}</option>
-                    ))}
-                  </select>
-                </div>
-              )}
-              {/* Round Robin toggle */}
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-xs text-text-muted font-medium">Round Robin</span>
-                <Toggle
-                  checked={providerStrategy === "round-robin"}
-                  onChange={handleRoundRobinToggle}
-                />
-                {providerStrategy === "round-robin" && (
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-xs text-text-muted">Sticky:</span>
-                    <input
-                      type="number"
-                      min={1}
-                      value={providerStickyLimit}
-                      onChange={(e) => handleStickyLimitChange(e.target.value)}
-                      placeholder="1"
-                      className="w-14 px-2 py-1 text-xs border border-border rounded-md bg-background focus:outline-none focus:border-primary"
-                    />
-                  </div>
-                )}
-              </div>
-              {/* ZenMux plan selector — only for zenmux-free provider */}
-              {providerId === "zenmux-free" && connections.length > 0 && (
-                <ZenmuxPlanSelector
-                  connectionId={connections[0].id}
-                  cookie={connections[0].apiKey || ""}
-                  currentPlan={connections[0].providerSpecificData?.zenmuxPlan || "free"}
-                  onPlanChanged={() => {
-                    // Refresh connections so the new plan is reflected.
-                    fetchConnections();
-                  }}
-                />
-              )}
-            </div>
-          </div>
+      {/* ── Collapsible sections ── */}
 
-          {connections.length === 0 ? (
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex items-center gap-3">
-                <div className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-primary/10 text-primary shrink-0">
-                  <span className="material-symbols-outlined text-[18px]">{isOAuth ? "lock" : "key"}</span>
-                </div>
-                <div className="min-w-0">
-                  <p className="text-sm text-text-muted">No connections yet</p>
-                  {hasDualAuthModes && (
-                    <p className="text-xs text-text-muted">
-                      Choose {oauthConnectionLabel} or {apiKeyConnectionLabel}.
-                    </p>
-                  )}
-                </div>
-              </div>
-              <div className="flex gap-2">
-                {hasDualAuthModes ? (
-                  <>
-                    <Button size="sm" icon="lock" variant="secondary" onClick={triggerOAuthConnection}>
-                      {oauthConnectionLabel}
-                    </Button>
-                    <Button size="sm" icon="key" onClick={triggerApiKeyConnection}>
-                      {apiKeyConnectionLabel}
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    {!isCompatible && providerId === "iflow" && (
-                      <Button size="sm" icon="cookie" variant="secondary" onClick={() => setShowIFlowCookieModal(true)}>
-                        Cookie
-                      </Button>
-                    )}
-                    {providerId === "codex" && (
-                      <Button size="sm" icon="playlist_add" variant="secondary" onClick={() => setShowBulkImportCodex(true)}>
-                        {translate("Bulk Add")}
-                      </Button>
-                    )}
-                    <Button
-                      size="sm"
-                      icon="add"
-                      onClick={triggerAddConnection}
-                    >
-                      {isCompatible ? "Add API Key" : (providerId === "iflow" ? "OAuth" : "Add Connection")}
-                    </Button>
-                  </>
-                )}
-              </div>
-            </div>
-          ) : (
-            <>
-              {oneByOneSummary && (
-                <div className="mb-4 rounded-lg border border-border bg-black/[0.02] px-3 py-2 text-xs text-text-muted dark:border-white/10 dark:bg-white/[0.03]">
-                  <div className="flex flex-wrap items-center gap-3">
-                    <span>Total: {oneByOneSummary.total}</span>
-                    <span>Completed: {oneByOneSummary.completed}</span>
-                    <span>Passed: {oneByOneSummary.passed}</span>
-                    <span>Failed: {oneByOneSummary.failed}</span>
-                    {oneByOneSummary.stopped && (
-                      <span className="text-warning">Stopped</span>
-                    )}
-                    {oneByOneRunning && oneByOneCurrentConnectionId && (
-                      <span>Running: {connections.find((conn) => conn.id === oneByOneCurrentConnectionId)?.name || oneByOneCurrentConnectionId}</span>
-                    )}
-                  </div>
-                </div>
-              )}
-              {connections.length > 0 && (
-                <div className="mb-3 flex items-center gap-2 border-b border-black/[0.03] pb-2 dark:border-white/[0.03]">
-                  <label className="flex cursor-pointer items-center gap-1.5 text-xs text-text-muted hover:text-primary">
-                    <input
-                      type="checkbox"
-                      checked={allSelected}
-                      onChange={toggleSelectAllConnections}
-                      className="h-3.5 w-3.5 rounded border-gray-300 text-primary focus:ring-primary"
-                    />
-                    Select All
-                  </label>
-                </div>
-              )}
-              {connectionsList}
-              {!isCompatible && (
-                <div className="mt-4 grid grid-cols-1 gap-2 sm:flex">
-                  {providerId === "iflow" && (
-                    <Button
-                      size="sm"
-                      icon="cookie"
-                      variant="secondary"
-                      onClick={() => setShowIFlowCookieModal(true)}
-                      title="Add connection using browser cookie"
-                      className="w-full sm:w-auto"
-                    >
-                      Cookie
-                    </Button>
-                  )}
-                  {providerId === "codex" && (
-                    <Button
-                      size="sm"
-                      icon="playlist_add"
-                      variant="secondary"
-                      onClick={() => setShowBulkImportCodex(true)}
-                      title={translate("Bulk import codex accounts from JSON")}
-                      className="w-full sm:w-auto"
-                    >
-                      {translate("Bulk Add")}
-                    </Button>
-                  )}
-                  {hasDualAuthModes ? (
-                    <>
-                      <Button
-                        size="sm"
-                        icon="lock"
-                        variant="secondary"
-                        onClick={triggerOAuthConnection}
-                        className="w-full sm:w-auto"
-                      >
-                        {oauthConnectionLabel}
-                      </Button>
-                      <Button
-                        size="sm"
-                        icon="key"
-                        onClick={triggerApiKeyConnection}
-                        className="w-full sm:w-auto"
-                      >
-                        {apiKeyConnectionLabel}
-                      </Button>
-                    </>
-                  ) : (
-                    <Button
-                      size="sm"
-                      icon="add"
-                      onClick={triggerAddConnection}
-                      className="w-full sm:w-auto"
-                    >
-                      Add
-                    </Button>
-                  )}
-                </div>
-              )}
-            </>
-          )}
-        </Card>
-      )}
+      {/* Connections */}
+      <CollapsibleSection
+        title="Connections"
+        icon="cable"
+        count={connections.length}
+        defaultExpanded
+      >
+        <ConnectionsCard
+          // identity
+          providerId={providerId}
+          isOAuth={isOAuth}
+          isCompatible={isCompatible}
+          isFreeNoAuth={isFreeNoAuth}
+          hasDualAuthModes={hasDualAuthModes}
+          oauthConnectionLabel={oauthConnectionLabel}
+          apiKeyConnectionLabel={apiKeyConnectionLabel}
+          thinkingConfig={thinkingConfig}
+          AUTO_PING_SETTINGS_KEYS={AUTO_PING_SETTINGS_KEYS}
+          // data
+          connections={connections}
+          proxyPools={proxyPools}
+          selectedConnectionIds={selectedConnectionIds}
+          selectedConnections={selectedConnections}
+          allSelected={allSelected}
+          oneByOneRunning={oneByOneRunning}
+          oneByOneStopping={oneByOneStopping}
+          oneByOneCurrentConnectionId={oneByOneCurrentConnectionId}
+          oneByOneResults={oneByOneResults}
+          oneByOneSummary={oneByOneSummary}
+          providerStrategy={providerStrategy}
+          providerStickyLimit={providerStickyLimit}
+          thinkingMode={thinkingMode}
+          autoPing={autoPing}
+          // modal state
+          showBulkProxyModal={showBulkProxyModal}
+          bulkUpdatingProxy={bulkUpdatingProxy}
+          activePools={activePools}
+          selectedProxySummary={selectedProxySummary}
+          // handlers
+          handleSwapPriority={handleSwapPriority}
+          handleUpdateConnectionStatus={handleUpdateConnectionStatus}
+          handleDelete={handleDelete}
+          handleBulkDelete={handleBulkDelete}
+          handleRunOneByOneTest={handleRunOneByOneTest}
+          handleStopOneByOneTest={handleStopOneByOneTest}
+          handleRoundRobinToggle={handleRoundRobinToggle}
+          handleStickyLimitChange={handleStickyLimitChange}
+          handleThinkingModeChange={handleThinkingModeChange}
+          handleAutoPingConnection={handleAutoPingConnection}
+          triggerOAuthConnection={triggerOAuthConnection}
+          triggerApiKeyConnection={triggerApiKeyConnection}
+          triggerAddConnection={triggerAddConnection}
+          toggleSelectConnection={toggleSelectConnection}
+          toggleSelectAllConnections={toggleSelectAllConnections}
+          openBulkProxyModal={openBulkProxyModal}
+          closeBulkProxyModal={closeBulkProxyModal}
+          applyProxyAssignments={applyProxyAssignments}
+          handleApplySinglePool={handleApplySinglePool}
+          handleApplyOneToOne={handleApplyOneToOne}
+          fetchConnections={fetchConnections}
+          setSelectedConnection={setSelectedConnection}
+          setShowEditModal={setShowEditModal}
+          setShowBulkProxyModal={setShowBulkProxyModal}
+          setShowIFlowCookieModal={setShowIFlowCookieModal}
+          setShowBulkImportCodex={setShowBulkImportCodex}
+          setConnections={setConnections}
+        />
+      </CollapsibleSection>
 
       {/* Health Timeline */}
-      <Card>
-        <div className="py-1">
+      <CollapsibleSection
+        title="Health"
+        icon="monitoring"
+        defaultExpanded={false}
+      >
+        <div className="px-4 py-3">
           <HealthTimeline providerId={providerId} />
         </div>
-      </Card>
+      </CollapsibleSection>
 
       {/* Models */}
-      <Card>
-        <div className="mb-4 flex flex-col gap-3">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <h2 className="text-lg font-semibold">
-              {"Available Models"}
-            </h2>
-            {!isCompatible && (() => {
-              const allIds = [
-                ...models,
-                ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
-              ].filter((m) => { const k = getModelKind(m); return !k || k === "llm"; }).map((m) => m.id);
-              const activeIds = allIds.filter((id) => !disabledModelIds.includes(id));
-              // Models visible after search filter — used to scope "Test All".
-              const q = modelSearchQuery.trim().toLowerCase();
-              const testableIds = activeIds.filter((id) =>
-                !q || id.toLowerCase().includes(q)
-              );
-              return (
-                <div className="flex flex-wrap gap-2">
-                  {disabledModelIds.length > 0 && (
-                    <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll}>
-                      Active All
-                    </Button>
-                  )}
-                  {activeIds.length > 0 && (
-                    <Button size="sm" variant="secondary" icon="block" onClick={() => handleDisableAll(activeIds)}>
-                      Disable All
-                    </Button>
-                  )}
-                  {(connections.length > 0 || isFreeNoAuth) && testableIds.length > 0 && (
-                    <Button
-                      size="sm"
-                      variant="primary"
-                      icon={testingAllModels ? "progress_activity" : "play_arrow"}
-                      onClick={() => handleTestAllModels(testableIds)}
-                      disabled={testingAllModels}
-                    >
-                      {testingAllModels ? "Testing..." : `Test All (${testableIds.length})`}
-                    </Button>
-                  )}
-                </div>
-              );
-            })()}
-          </div>
-          {/* Search box — applies to both built-in and custom model rows */}
-          <div className="sm:max-w-xs">
-            <Input
-              type="search"
-              placeholder="Search models..."
-              value={modelSearchQuery}
-              onChange={(e) => setModelSearchQuery(e.target.value)}
-              className="w-full"
-            />
-          </div>
-        </div>
-        {!!modelsTestError && (
-          <p className="text-xs text-danger mb-3 break-words">{modelsTestError}</p>
-        )}
-        {renderModelsSection()}
-      </Card>
+      <CollapsibleSection
+        title="Models"
+        icon="apps"
+        count={models.length}
+        defaultExpanded
+      >
+        <ModelsCard
+          // identity
+          providerId={providerId}
+          isCompatible={isCompatible}
+          isAnthropicCompatible={isAnthropicCompatible}
+          isFreeNoAuth={isFreeNoAuth}
+          providerStorageAlias={providerStorageAlias}
+          providerDisplayAlias={providerDisplayAlias}
+          // data
+          models={models}
+          kiloFreeModels={kiloFreeModels}
+          modelAliases={modelAliases}
+          customModels={customModels}
+          disabledModelIds={disabledModelIds}
+          modelTestResults={modelTestResults}
+          testingModelIds={testingModelIds}
+          testingAllModels={testingAllModels}
+          modelsTestError={modelsTestError}
+          modelSearchQuery={modelSearchQuery}
+          connections={connections}
+          suggestedModels={suggestedModels}
+          importingQoderModels={importingQoderModels}
+          copied={copied}
+          // hooks
+          getCaps={getCaps}
+          // handlers
+          copy={copy}
+          handleTestModel={handleTestModel}
+          handleTestAllModels={handleTestAllModels}
+          handleDisableModel={handleDisableModel}
+          handleEnableModel={handleEnableModel}
+          handleDisableAll={handleDisableAll}
+          handleEnableAll={handleEnableAll}
+          handleSetAlias={handleSetAlias}
+          handleDeleteAlias={handleDeleteAlias}
+          handleAddCustomModel={handleAddCustomModel}
+          handleDeleteCustomModel={handleDeleteCustomModel}
+          handleImportQoderModels={handleImportQoderModels}
+          setModelSearchQuery={setModelSearchQuery}
+          setShowAddCustomModel={setShowAddCustomModel}
+        />
+      </CollapsibleSection>
 
-      {bulkActionModal}
-
-      {/* Modals */}
+      {/* ── Modals (unchanged) ── */}
       {providerId === "kiro" ? (
         <KiroOAuthWrapper
           isOpen={showOAuthModal}
@@ -1722,33 +1152,14 @@ export default function ProviderDetailPage() {
           onClose={() => setShowOAuthModal(false)}
         />
       ) : providerId === "cursor" ? (
-        <CursorAuthModal
-          isOpen={showOAuthModal}
-          onSuccess={handleOAuthSuccess}
-          onClose={() => setShowOAuthModal(false)}
-        />
+        <CursorAuthModal isOpen={showOAuthModal} onSuccess={handleOAuthSuccess} onClose={() => setShowOAuthModal(false)} />
       ) : providerId === "gitlab" ? (
-        <GitLabAuthModal
-          isOpen={showOAuthModal}
-          providerInfo={providerInfo}
-          onSuccess={handleOAuthSuccess}
-          onClose={() => setShowOAuthModal(false)}
-        />
+        <GitLabAuthModal isOpen={showOAuthModal} providerInfo={providerInfo} onSuccess={handleOAuthSuccess} onClose={() => setShowOAuthModal(false)} />
       ) : (
-        <OAuthModal
-          isOpen={showOAuthModal}
-          provider={providerId}
-          providerInfo={providerInfo}
-          onSuccess={handleOAuthSuccess}
-          onClose={() => setShowOAuthModal(false)}
-        />
+        <OAuthModal isOpen={showOAuthModal} provider={providerId} providerInfo={providerInfo} onSuccess={handleOAuthSuccess} onClose={() => setShowOAuthModal(false)} />
       )}
       {providerId === "iflow" && (
-        <IFlowCookieModal
-          isOpen={showIFlowCookieModal}
-          onSuccess={handleIFlowCookieSuccess}
-          onClose={() => setShowIFlowCookieModal(false)}
-        />
+        <IFlowCookieModal isOpen={showIFlowCookieModal} onSuccess={handleIFlowCookieSuccess} onClose={() => setShowIFlowCookieModal(false)} />
       )}
       <AddApiKeyModal
         isOpen={showAddApiKeyModal}
@@ -1763,10 +1174,7 @@ export default function ProviderDetailPage() {
         error={addConnectionError}
         onSave={handleSaveApiKey}
         onBulkDone={fetchConnections}
-        onClose={() => {
-          setAddConnectionError("");
-          setShowAddApiKeyModal(false);
-        }}
+        onClose={() => { setAddConnectionError(""); setShowAddApiKeyModal(false); }}
       />
       <EditConnectionModal
         isOpen={showEditModal}
@@ -1789,23 +1197,13 @@ export default function ProviderDetailPage() {
           isOpen={showAddCustomModel}
           providerAlias={providerStorageAlias}
           providerDisplayAlias={providerDisplayAlias}
-          onSave={async (modelId) => {
-            await handleAddCustomModel(modelId, "llm", providerStorageAlias);
-            setShowAddCustomModel(false);
-          }}
+          onSave={async (modelId) => { await handleAddCustomModel(modelId, "llm", providerStorageAlias); setShowAddCustomModel(false); }}
           onClose={() => setShowAddCustomModel(false)}
         />
       )}
-
       {providerId === "codex" && (
-        <BulkImportCodexModal
-          isOpen={showBulkImportCodex}
-          onClose={() => setShowBulkImportCodex(false)}
-          onSuccess={fetchConnections}
-        />
+        <BulkImportCodexModal isOpen={showBulkImportCodex} onClose={() => setShowBulkImportCodex(false)} onSuccess={fetchConnections} />
       )}
-
-      {/* AG Risk Confirmation Modal */}
       <ConfirmModal
         isOpen={showAgRiskModal}
         onClose={() => setShowAgRiskModal(false)}
@@ -1816,8 +1214,6 @@ export default function ProviderDetailPage() {
         cancelText="Cancel"
         variant="danger"
       />
-
-      {/* Confirm Modal */}
       <ConfirmModal
         isOpen={!!confirmState}
         onClose={() => setConfirmState(null)}

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderKpis.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderKpis.js
@@ -1,0 +1,83 @@
+"use client";
+
+import { Card } from "@/shared/components";
+
+/**
+ * KPI row for the Providers page — replaces the old ProviderSummary band.
+ * Four tiles in a responsive grid: Total / Connected / Errors / Ready.
+ *
+ * Pattern lifted from ComboOverview.js: Card padding="sm", color-tinted
+ * size-9 icon chip (inline `${color}15` alpha for ~8% tint), bold value,
+ * micro-uppercase label.
+ *
+ * The Errors tile is interactive: clicking it filters the grid to only
+ * providers with errors (onFilter("errors")).
+ */
+const KPIS = [
+  { key: "total", label: "Total", icon: "dns", color: "#3B82F6" },
+  { key: "connected", label: "Connected", icon: "link", color: "#10B981" },
+  { key: "errors", label: "Errors", icon: "error", color: "#E11D48" },
+  { key: "ready", label: "Ready", icon: "bolt", color: "#F59E0B" },
+];
+
+export default function ProviderKpis({ counts, activeFilter, onFilter }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      {KPIS.map((kpi) => {
+        const value = counts[kpi.key] || 0;
+        const isActive = activeFilter === kpi.key;
+        // Errors tile is clickable to filter; Total/Connected/Ready are static
+        // (clicking them doesn't have a meaningful filter target today).
+        const clickable = kpi.key === "errors" && value > 0;
+        return (
+          <Card
+            key={kpi.key}
+            padding="sm"
+            className={`flex items-center gap-3 transition-all ${
+              clickable ? "cursor-pointer hover:border-primary/35 hover:bg-panel-elev" : ""
+            } ${isActive ? "border-primary/35 bg-primary/5" : ""}`}
+          >
+            {clickable ? (
+              <button
+                type="button"
+                onClick={() => onFilter(isActive ? "all" : kpi.key)}
+                className="flex w-full items-center gap-3 text-left"
+                aria-label={`Filter by ${kpi.label.toLowerCase()}`}
+              >
+                <KpiContent kpi={kpi} value={value} />
+              </button>
+            ) : (
+              <KpiContent kpi={kpi} value={value} />
+            )}
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+function KpiContent({ kpi, value }) {
+  return (
+    <>
+      <div
+        className="flex size-9 shrink-0 items-center justify-center rounded-lg"
+        style={{ backgroundColor: `${kpi.color}15` }}
+      >
+        <span
+          className="material-symbols-outlined text-[20px]"
+          style={{ color: kpi.color }}
+        >
+          {kpi.icon}
+        </span>
+      </div>
+      <div className="min-w-0">
+        <div className="font-mono text-2xl font-bold leading-none text-text-main">
+          {value}
+        </div>
+        <div className="mt-1 text-[10px] uppercase tracking-wide text-text-muted">
+          {kpi.label}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderTile.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderTile.js
@@ -1,0 +1,187 @@
+"use client";
+
+import Link from "next/link";
+import ProviderIcon from "@/shared/components/ProviderIcon";
+import { Badge, Toggle, Tooltip } from "@/shared/components";
+import { cn } from "@/shared/utils/cn";
+import { OPENAI_COMPATIBLE_PREFIX, ANTHROPIC_COMPATIBLE_PREFIX } from "@/shared/constants/providers";
+import { getProviderIconPath } from "@/shared/utils/providerIcon";
+
+/**
+ * Rich provider tile — replaces ProviderCardV2 in the redesigned Providers page.
+ *
+ * Shows more detail at a glance than the old compact row:
+ *   - Larger icon (size-10 tinted chip)
+ *   - Name + NEW badge + connection count
+ *   - Status badges (Connected / Error / Disabled / Ready / Coming Soon)
+ *   - Bottom action bar: quick-test (if connected), settings link, toggle
+ *
+ * Pattern follows ComboCard (Card padding="none", top Link area, bottom
+ * border-t action bar) and the Quota provider cards (icon box, status pills,
+ * h-8 icon buttons wrapped in Tooltip).
+ *
+ * The entire top area is a Link to the detail page. The action bar buttons
+ * stopPropagation so toggle/test don't navigate.
+ */
+export default function ProviderTile({
+  providerId,
+  provider,
+  stats,
+  onToggle,
+  onTest,
+  isNoAuth = false,
+  comingSoon = false,
+  isNew = false,
+  testing = false,
+}) {
+  const isCompatible = providerId.startsWith(OPENAI_COMPATIBLE_PREFIX);
+  const isAnthropicCompatible = providerId.startsWith(ANTHROPIC_COMPATIBLE_PREFIX);
+  const { connected, error, errorCode, allDisabled } = stats;
+  const iconPath = getProviderIconPath(providerId, provider.apiType);
+  const hasConnections = stats.total > 0;
+  const showToggle = hasConnections && onToggle && !comingSoon;
+
+  return (
+    <div
+      className={cn(
+        "group relative flex flex-col overflow-hidden rounded-panel border border-border-subtle bg-panel shadow-[var(--shadow-soft)] transition-all hover:border-primary/35 hover:bg-panel-elev hover:shadow-[var(--shadow-warm)]",
+        comingSoon && "opacity-70",
+      )}
+    >
+      {/* ── Top: clickable link area ── */}
+      <Link
+        href={`/dashboard/providers/${providerId}`}
+        className="flex min-w-0 flex-col gap-2 px-3 pb-2 pt-3"
+      >
+        {/* Icon + name row */}
+        <div className="flex items-center gap-2.5">
+          <div
+            className="flex size-10 shrink-0 items-center justify-center rounded-lg"
+            style={{
+              backgroundColor: `${provider.color?.length > 7 ? provider.color.slice(0, 7) : provider.color}15`,
+            }}
+          >
+            <ProviderIcon
+              src={iconPath}
+              alt={provider.name}
+              size={32}
+              className="object-contain rounded-lg max-w-[32px] max-h-[32px]"
+              fallbackText={provider.textIcon || provider.id?.slice(0, 2).toUpperCase()}
+              fallbackColor={provider.color}
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="flex items-center gap-1.5 text-sm font-semibold leading-tight text-text-main">
+              <span className="truncate">{provider.name}</span>
+              {isNew && (
+                <span className="inline-flex shrink-0 items-center rounded-full bg-primary/12 px-1.5 py-0.5 text-[10px] font-bold text-primary ring-1 ring-primary/20">
+                  NEW
+                </span>
+              )}
+            </h3>
+            {hasConnections ? (
+              <p className="mt-0.5 text-[11px] text-text-muted">
+                {connected > 0 ? `${connected} active` : `${stats.total} connection${stats.total > 1 ? "s" : ""}`}
+              </p>
+            ) : isNoAuth ? (
+              <p className="mt-0.5 text-[11px] text-text-muted">No key needed</p>
+            ) : (
+              <p className="mt-0.5 text-[11px] text-text-muted">Not connected</p>
+            )}
+          </div>
+        </div>
+
+        {/* Status badges */}
+        <div className="flex flex-wrap items-center gap-1.5">
+          {allDisabled ? (
+            <Badge variant="default" size="sm">
+              <span className="flex items-center gap-1">
+                <span className="material-symbols-outlined text-[12px]">pause_circle</span>
+                Disabled
+              </span>
+            </Badge>
+          ) : isNoAuth && connected === 0 && error === 0 ? (
+            <Badge variant="success" size="sm" dot>Ready</Badge>
+          ) : connected > 0 ? (
+            <Badge variant="success" size="sm" dot>{connected} Connected</Badge>
+          ) : null}
+
+          {error > 0 && (
+            <Badge variant="error" size="sm" dot>
+              {errorCode ? `${error} Error (${errorCode})` : `${error} Error`}
+            </Badge>
+          )}
+
+          {comingSoon && (
+            <Badge variant="warning" size="sm">
+              <span className="flex items-center gap-1">
+                <span className="material-symbols-outlined text-[12px]">schedule</span>
+                Soon
+              </span>
+            </Badge>
+          )}
+
+          {isCompatible && (
+            <Badge variant="default" size="sm">
+              {provider.apiType === "responses" ? "Responses" : "Chat"}
+            </Badge>
+          )}
+          {isAnthropicCompatible && <Badge variant="default" size="sm">Messages</Badge>}
+        </div>
+      </Link>
+
+      {/* ── Bottom: action bar ── */}
+      <div className="flex items-center gap-1 border-t border-border-subtle px-3 py-2">
+        {/* Quick test (only when connected) */}
+        {hasConnections && onTest && (
+          <Tooltip text={testing ? "Testing..." : "Test provider"}>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onTest(providerId);
+              }}
+              disabled={testing}
+              className="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-surface-2 hover:text-primary disabled:opacity-50"
+              aria-label="Test provider"
+            >
+              <span className={cn("material-symbols-outlined text-[16px]", testing && "animate-spin")}>
+                {testing ? "progress_activity" : "bolt"}
+              </span>
+            </button>
+          </Tooltip>
+        )}
+
+        {/* Settings link */}
+        <Tooltip text="Configure">
+          <Link
+            href={`/dashboard/providers/${providerId}`}
+            onClick={(e) => e.stopPropagation()}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-surface-2 hover:text-primary"
+            aria-label="Configure provider"
+          >
+            <span className="material-symbols-outlined text-[16px]">settings</span>
+          </Link>
+        </Tooltip>
+
+        {/* Spacer pushes toggle right */}
+        <div className="flex-1" />
+
+        {/* Toggle (only if has connections) */}
+        {showToggle && (
+          <div
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onToggle(!allDisabled ? false : true);
+            }}
+            className="opacity-80 sm:opacity-50 sm:group-hover:opacity-100"
+          >
+            <Toggle size="sm" checked={!allDisabled} onChange={() => {}} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderToolbar.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderToolbar.js
@@ -1,0 +1,107 @@
+"use client";
+
+import { cn } from "@/shared/utils/cn";
+
+/**
+ * Filter chips + sort control bar for the Providers page.
+ *
+ * Left: category filter pills (All / Connected / Errors / OAuth / API Key /
+ * Free / Cookie / Custom). Each shows a live count badge when > 0.
+ * Right: sort <select> (Priority / Name / Connections).
+ *
+ * Pattern from Quota ProviderLimits toolbar: h-8 rounded-lg border chips,
+ * active = border-primary/30 bg-primary/5 text-primary.
+ */
+const FILTER_CHIPS = [
+  { value: "all", label: "All" },
+  { value: "connected", label: "Connected" },
+  { value: "errors", label: "Errors" },
+  { value: "oauth", label: "OAuth" },
+  { value: "apikey", label: "API Key" },
+  { value: "free", label: "Free" },
+  { value: "cookie", label: "Cookie" },
+  { value: "custom", label: "Custom" },
+];
+
+const SORT_OPTIONS = [
+  { value: "priority", label: "Priority" },
+  { value: "name", label: "Name" },
+  { value: "connections", label: "Connections" },
+];
+
+export default function ProviderToolbar({
+  filter,
+  onFilter,
+  sortBy,
+  onSort,
+  counts = {},
+  total,
+  isSearching,
+}) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      {/* Filter chips */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {FILTER_CHIPS.map((chip) => {
+          // Don't render category chips with zero entries (unless searching,
+          // where counts may not match the searched subset).
+          const chipCount = counts[chip.value];
+          const showCount =
+            chipCount !== undefined &&
+            chipCount !== total &&
+            chip.value !== "all";
+          if (!isSearching && chipCount === 0 && chip.value !== "all") return null;
+
+          const isActive = filter === chip.value;
+          return (
+            <button
+              key={chip.value}
+              type="button"
+              onClick={() => onFilter(chip.value)}
+              className={cn(
+                "flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-xs font-medium transition-colors",
+                isActive
+                  ? "border-primary/30 bg-primary/5 text-primary"
+                  : "border-border bg-black/[0.02] text-text-primary hover:bg-surface-2 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10",
+              )}
+              aria-pressed={isActive}
+            >
+              {chip.label}
+              {showCount && (
+                <span
+                  className={cn(
+                    "rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums",
+                    isActive
+                      ? "bg-primary/15 text-primary"
+                      : "bg-black/5 text-text-muted dark:bg-white/10",
+                  )}
+                >
+                  {chipCount}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Sort control */}
+      <div className="flex items-center gap-1.5">
+        <span className="material-symbols-outlined text-[16px] text-text-muted">
+          sort
+        </span>
+        <select
+          value={sortBy}
+          onChange={(e) => onSort(e.target.value)}
+          className="h-8 rounded-lg border border-border bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-surface-2 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10"
+          aria-label="Sort providers"
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -1,47 +1,38 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import PropTypes from "prop-types";
-import Link from "next/link";
-import { Card, Button, Badge, CardSkeleton, PageHeader, Modal, EmptyState } from "@/shared/components";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { Button, CardSkeleton, PageHeader, Modal, EmptyState } from "@/shared/components";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS } from "@/shared/constants/config";
 import {
   FREE_PROVIDERS,
   FREE_TIER_PROVIDERS,
   WEB_COOKIE_PROVIDERS,
-  OPENAI_COMPATIBLE_PREFIX,
-  ANTHROPIC_COMPATIBLE_PREFIX,
 } from "@/shared/constants/providers";
 import { useNotificationStore } from "@/store/notificationStore";
 import { useHeaderSearchStore } from "@/store/headerSearchStore";
 import { useNewBadge } from "@/shared/hooks/useNewBadge";
 
-import ProviderCardV2 from "./components/ProviderCardV2";
-import ProviderSection from "./components/ProviderSection";
+import ProviderTile from "./components/ProviderTile";
+import ProviderKpis from "./components/ProviderKpis";
+import ProviderToolbar from "./components/ProviderToolbar";
 import ProviderTestResults from "./components/ProviderTestResults";
-import ProviderSummary from "./components/ProviderSummary";
 import AddCompatibleModal from "./components/AddCompatibleModal";
 import {
   makeGetProviderStats,
   makeMatchSearch,
   makeSortByPriority,
   resolveStatsAuthType,
-  getConnectionErrorTag,
 } from "./components/helpers";
 
 export default function ProvidersPage() {
   const [connections, setConnections] = useState([]);
   const [providerNodes, setProviderNodes] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [showAllApikey, setShowAllApikey] = useState(false);
   const { isNew: isNewProvider, markSeen: markProviderSeen } = useNewBadge("providers");
 
-  // Collapsible sections
-  const [showCustom, setShowCustom] = useState(false);
-  const [showCookies, setShowCookies] = useState(false);
-  const [showOauth, setShowOauth] = useState(true);
-  const [showFree, setShowFree] = useState(true);
-  const [showApikey, setShowApikey] = useState(true);
+  // Unified filter + sort (replaces the old 6 section-collapse flags)
+  const [filter, setFilter] = useState("all");
+  const [sortBy, setSortBy] = useState("priority");
 
   // Modals
   const [showAddCompatibleModal, setShowAddCompatibleModal] = useState(false);
@@ -50,7 +41,7 @@ export default function ProvidersPage() {
   // Test
   const [testingMode, setTestingMode] = useState(null);
   const [testResults, setTestResults] = useState(null);
-  const testingRef = useRef(false); // fix: race condition guard
+  const testingRef = useRef(false); // race-condition guard
 
   const notify = useNotificationStore();
   const searchQuery = useHeaderSearchStore((s) => s.query);
@@ -96,14 +87,12 @@ export default function ProvidersPage() {
   const sortByPriority = makeSortByPriority(getProviderStats);
 
   // ── Toggle provider ────────────────────────────────────────────────────────
-  // fix: compute matches inside setConnections updater to avoid snapshot drift
 
   const handleToggleProvider = useCallback((providerId, authType, newActive) => {
     const authTypes = Array.isArray(authType) ? authType : [authType];
     const matches = (c) => c.provider === providerId && authTypes.includes(c.authType);
     setConnections((prev) => {
       const toUpdate = prev.filter(matches);
-      // Fire PUT requests for the matched connections
       Promise.allSettled(
         toUpdate.map((c) =>
           fetch(`/api/providers/${c.id}`, {
@@ -118,7 +107,6 @@ export default function ProvidersPage() {
   }, []);
 
   // ── Batch test ─────────────────────────────────────────────────────────────
-  // fix: ref guard for race condition, refetch connections after test
 
   const handleBatchTest = useCallback(async (mode, providerId = null) => {
     if (testingRef.current) return;
@@ -138,7 +126,6 @@ export default function ProvidersPage() {
         if (failed === 0) notify.success(`All ${total} tests passed`);
         else notify.warning(`${passed}/${total} passed, ${failed} failed`);
       }
-      // fix: refetch so card badges reflect fresh test status
       fetchConnections();
     } catch {
       setTestResults({ error: "Test request failed" });
@@ -149,82 +136,227 @@ export default function ProvidersPage() {
     }
   }, [notify, fetchConnections]);
 
-  // ── Provider entries (filtered + sorted) ───────────────────────────────────
+  // ── Build unified provider list (all categories merged into one flat array)
+  //
+  // Each entry is normalized to a common shape tagged with `category` for
+  // filtering. This replaces the old 5 separate section arrays.
 
-  const compatibleProviders = providerNodes
-    .filter((n) => n.type === "openai-compatible")
-    .map((n) => ({ id: n.id, name: n.name || "OpenAI Compatible", color: "#10A37F", textIcon: "OC", apiType: n.apiType }))
-    .filter((p) => matchSearch(p.name, p.id));
+  const allEntries = useMemo(() => {
+    const entries = [];
 
-  const anthropicCompatibleProviders = providerNodes
-    .filter((n) => n.type === "anthropic-compatible")
-    .map((n) => ({ id: n.id, name: n.name || "Anthropic Compatible", color: "#D97757", textIcon: "AC" }))
-    .filter((p) => matchSearch(p.name, p.id));
+    // Custom (OpenAI/Anthropic compatible) from providerNodes
+    for (const node of providerNodes) {
+      const id = node.id;
+      const name = node.name || (node.type === "anthropic-compatible" ? "Anthropic Compatible" : "OpenAI Compatible");
+      if (!matchSearch(name, id)) continue;
+      entries.push({
+        id,
+        name,
+        color: node.type === "anthropic-compatible" ? "#D97757" : "#10A37F",
+        textIcon: node.type === "anthropic-compatible" ? "AC" : "OC",
+        apiType: node.apiType,
+        category: "custom",
+        priority: 999,
+        authTypes: "apikey",
+        stats: getProviderStats(id, "apikey"),
+        isNew: isNewProvider(id),
+        isNoAuth: false,
+        comingSoon: false,
+      });
+    }
 
-  const oauthEntries = sortByPriority(
-    Object.entries(OAUTH_PROVIDERS).filter(([, i]) => !i.hidden && matchSearch(i.name, i.id, i.alias)),
-    "oauth",
-  );
-  const freeEntries = Object.entries(FREE_PROVIDERS)
-    .filter(([, i]) => !i.hidden && matchSearch(i.name, i.id, i.alias))
-    .sort(([, a], [, b]) => (b.noAuth ? 1 : 0) - (a.noAuth ? 1 : 0));
-  const freeTierEntries = sortByPriority(
-    Object.entries(FREE_TIER_PROVIDERS).filter(([, i]) => !i.hidden && matchSearch(i.name, i.id, i.alias)),
-    "apikey",
-  );
-  const apikeyEntries = Object.entries(APIKEY_PROVIDERS)
-    .filter(([, i]) => !i.hidden && (i.serviceKinds ?? ["llm"]).includes("llm") && matchSearch(i.name, i.id, i.alias))
-    .sort(([ka, a], [kb, b]) => {
-      const ca = getProviderStats(ka, "apikey").total > 0 ? 0 : 1;
-      const cb = getProviderStats(kb, "apikey").total > 0 ? 0 : 1;
-      if (ca !== cb) return ca - cb;
-      return (a.name || "").localeCompare(b.name || "");
-    });
-  const cookieEntries = Object.entries(WEB_COOKIE_PROVIDERS)
-    .filter(([, i]) => !i.hidden && matchSearch(i.name, i.id, i.alias))
-    .sort(([ka, a], [kb, b]) => {
-      const ca = getProviderStats(ka, "cookie").total > 0 ? 0 : 1;
-      const cb = getProviderStats(kb, "cookie").total > 0 ? 0 : 1;
-      if (ca !== cb) return ca - cb;
-      return (a.name || "").localeCompare(b.name || "");
-    });
+    // OAuth providers
+    for (const [key, info] of Object.entries(OAUTH_PROVIDERS)) {
+      if (info.hidden) continue;
+      if (!matchSearch(info.name, info.id, info.alias)) continue;
+      const at = resolveStatsAuthType(info, "oauth");
+      entries.push({
+        id: key,
+        name: info.name,
+        color: info.color,
+        textIcon: info.textIcon,
+        category: "oauth",
+        priority: info.priority ?? 100,
+        authTypes: at,
+        stats: getProviderStats(key, at),
+        isNew: isNewProvider(key),
+        isNoAuth: false,
+        comingSoon: !!info.comingSoon,
+      });
+    }
 
-  const isApikeySearching = isSearching;
-  const visibleApikeyEntries = isApikeySearching || showAllApikey ? apikeyEntries : apikeyEntries.slice(0, 20);
+    // Free providers (no-auth + free-tier)
+    for (const [key, info] of Object.entries(FREE_PROVIDERS)) {
+      if (info.hidden) continue;
+      if (!matchSearch(info.name, info.id, info.alias)) continue;
+      const freeAuthTypes = key === "kiro" ? ["oauth", "apikey", "api_key"] : "oauth";
+      entries.push({
+        id: key,
+        name: info.name,
+        color: info.color,
+        textIcon: info.textIcon,
+        category: "free",
+        priority: info.priority ?? 200,
+        authTypes: freeAuthTypes,
+        stats: getProviderStats(key, freeAuthTypes),
+        isNew: isNewProvider(key),
+        isNoAuth: !!info.noAuth,
+        comingSoon: !!info.comingSoon,
+      });
+    }
 
-  // ── Summary stats ──────────────────────────────────────────────────────────
+    for (const [key, info] of Object.entries(FREE_TIER_PROVIDERS)) {
+      if (info.hidden) continue;
+      if (!matchSearch(info.name, info.id, info.alias)) continue;
+      entries.push({
+        id: key,
+        name: info.name,
+        color: info.color,
+        textIcon: info.textIcon,
+        category: "free",
+        priority: info.priority ?? 210,
+        authTypes: "apikey",
+        stats: getProviderStats(key, "apikey"),
+        isNew: isNewProvider(key),
+        isNoAuth: !!info.noAuth,
+        comingSoon: !!info.comingSoon,
+      });
+    }
 
-  const totalProviders = oauthEntries.length + freeEntries.length + freeTierEntries.length + apikeyEntries.length + cookieEntries.length;
-  const allProviderIds = [...oauthEntries, ...freeEntries, ...freeTierEntries, ...apikeyEntries, ...cookieEntries].map(([k]) => k);
-  const connectedCount = allProviderIds.filter((id) => {
-    const info = OAUTH_PROVIDERS[id] || APIKEY_PROVIDERS[id] || FREE_PROVIDERS[id] || FREE_TIER_PROVIDERS[id] || WEB_COOKIE_PROVIDERS[id];
-    const at = resolveStatsAuthType(info, info?.authType || "apikey");
-    return getProviderStats(id, at).connected > 0;
-  }).length;
-  const errorCount = allProviderIds.filter((id) => {
-    const info = OAUTH_PROVIDERS[id] || APIKEY_PROVIDERS[id] || FREE_PROVIDERS[id] || FREE_TIER_PROVIDERS[id] || WEB_COOKIE_PROVIDERS[id];
-    const at = resolveStatsAuthType(info, info?.authType || "apikey");
-    return getProviderStats(id, at).error > 0;
-  }).length;
+    // API Key providers (LLM only)
+    for (const [key, info] of Object.entries(APIKEY_PROVIDERS)) {
+      if (info.hidden) continue;
+      if (!(info.serviceKinds ?? ["llm"]).includes("llm")) continue;
+      if (!matchSearch(info.name, info.id, info.alias)) continue;
+      entries.push({
+        id: key,
+        name: info.name,
+        color: info.color,
+        textIcon: info.textIcon,
+        category: "apikey",
+        priority: info.priority ?? 300,
+        authTypes: "apikey",
+        stats: getProviderStats(key, "apikey"),
+        isNew: isNewProvider(key),
+        isNoAuth: !!info.noAuth,
+        comingSoon: !!info.comingSoon,
+      });
+    }
 
-  // ── Render ─────────────────────────────────────────────────────────────────
+    // Cookie providers
+    for (const [key, info] of Object.entries(WEB_COOKIE_PROVIDERS)) {
+      if (info.hidden) continue;
+      if (!matchSearch(info.name, info.id, info.alias)) continue;
+      entries.push({
+        id: key,
+        name: info.name,
+        color: info.color,
+        textIcon: info.textIcon,
+        category: "cookie",
+        priority: info.priority ?? 400,
+        authTypes: "cookie",
+        stats: getProviderStats(key, "cookie"),
+        isNew: isNewProvider(key),
+        isNoAuth: !!info.noAuth,
+        comingSoon: !!info.comingSoon,
+      });
+    }
+
+    return entries;
+  }, [providerNodes, connections, searchQuery, isNewProvider]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── KPI counts ─────────────────────────────────────────────────────────────
+
+  const kpiCounts = useMemo(() => {
+    let connected = 0;
+    let errors = 0;
+    let ready = 0;
+    for (const e of allEntries) {
+      if (e.stats.connected > 0) connected++;
+      if (e.stats.error > 0) errors++;
+      if (e.isNoAuth && e.stats.connected === 0 && e.stats.error === 0) ready++;
+      if (!e.isNoAuth && e.stats.connected === 0 && e.stats.error === 0 && e.stats.total === 0) ready++;
+    }
+    return {
+      total: allEntries.length,
+      connected,
+      errors,
+      ready,
+    };
+  }, [allEntries]);
+
+  // ── Filter counts (for chip badges) ─────────────────────────────────────────
+
+  const filterCounts = useMemo(() => {
+    const c = { all: allEntries.length, connected: 0, errors: 0, oauth: 0, apikey: 0, free: 0, cookie: 0, custom: 0 };
+    for (const e of allEntries) {
+      if (e.stats.connected > 0) c.connected++;
+      if (e.stats.error > 0) c.errors++;
+      c[e.category]++;
+    }
+    return c;
+  }, [allEntries]);
+
+  // ── Apply filter + sort ─────────────────────────────────────────────────────
+
+  const visibleEntries = useMemo(() => {
+    let list = allEntries;
+
+    // Category / status filter
+    if (filter !== "all") {
+      if (filter === "connected") {
+        list = list.filter((e) => e.stats.connected > 0);
+      } else if (filter === "errors") {
+        list = list.filter((e) => e.stats.error > 0);
+      } else {
+        list = list.filter((e) => e.category === filter);
+      }
+    }
+
+    // Sort
+    const sorted = [...list];
+    if (sortBy === "name") {
+      sorted.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    } else if (sortBy === "connections") {
+      // Connected first (desc), then by total (desc), then alphabetical
+      sorted.sort((a, b) => {
+        const ac = a.stats.connected > 0 ? 0 : 1;
+        const bc = b.stats.connected > 0 ? 0 : 1;
+        if (ac !== bc) return ac - bc;
+        return (b.stats.total || 0) - (a.stats.total || 0) || (a.name || "").localeCompare(b.name || "");
+      });
+    } else {
+      // priority (default): connected-first, then by registry priority, then alpha
+      sorted.sort((a, b) => {
+        const ac = a.stats.total > 0 ? 0 : 1;
+        const bc = b.stats.total > 0 ? 0 : 1;
+        if (ac !== bc) return ac - bc;
+        if (a.priority !== b.priority) return a.priority - b.priority;
+        return (a.name || "").localeCompare(b.name || "");
+      });
+    }
+
+    return sorted;
+  }, [allEntries, filter, sortBy]);
+
+  // ── Loading ────────────────────────────────────────────────────────────────
 
   if (loading) {
     return (
-      <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-6">
         <CardSkeleton />
         <CardSkeleton />
       </div>
     );
   }
 
-  const hasAnyResult =
-    compatibleProviders.length > 0 || anthropicCompatibleProviders.length > 0 ||
-    oauthEntries.length > 0 || freeEntries.length > 0 || freeTierEntries.length > 0 ||
-    apikeyEntries.length > 0 || cookieEntries.length > 0;
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const showSearchEmpty = isSearching && visibleEntries.length === 0;
+  const showNoProviders = !isSearching && allEntries.length === 0;
 
   return (
-    <div className="flex min-w-0 flex-col gap-6">
+    <div className="flex min-w-0 flex-col gap-5">
       <PageHeader
         title="Providers"
         description="Connect, configure, and manage AI providers"
@@ -237,177 +369,78 @@ export default function ProvidersPage() {
         }
       />
 
-      {/* Summary band */}
-      <ProviderSummary
-        totalProviders={totalProviders}
-        connectedProviders={connectedCount}
-        errorCount={errorCount}
-        onTestAll={() => handleBatchTest("all")}
-        testingMode={testingMode}
+      {/* KPI row */}
+      <ProviderKpis
+        counts={kpiCounts}
+        activeFilter={filter}
+        onFilter={setFilter}
       />
 
-      {/* Search no-results */}
-      {isSearching && !hasAnyResult && (
-        <EmptyState
-          icon="search_off"
-          title={`No providers match "${searchQuery}"`}
-          description="Try a different search term, or browse the sections below."
+      {/* Global Test All — inline button, shown when there are connections */}
+      {kpiCounts.connected > 0 && (
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            variant="outline"
+            icon={testingMode === "all" ? "progress_activity" : "bolt"}
+            onClick={() => handleBatchTest("all")}
+            disabled={!!testingMode}
+            className={testingMode === "all" ? "animate-pulse" : ""}
+          >
+            {testingMode === "all" ? "Testing All..." : "Test All Providers"}
+          </Button>
+        </div>
+      )}
+
+      {/* Filter + sort toolbar */}
+      {!showNoProviders && (
+        <ProviderToolbar
+          filter={filter}
+          onFilter={setFilter}
+          sortBy={sortBy}
+          onSort={setSortBy}
+          counts={filterCounts}
+          total={allEntries.length}
+          isSearching={isSearching}
         />
       )}
 
-      {/* Custom Providers */}
-      <ProviderSection
-        title="Custom Providers (OpenAI/Anthropic Compatible)"
-        icon="extension"
-        count={compatibleProviders.length + anthropicCompatibleProviders.length}
-        isExpanded={showCustom}
-        onToggle={() => setShowCustom((v) => !v)}
-        isSearching={isSearching}
-        hasContent={compatibleProviders.length > 0 || anthropicCompatibleProviders.length > 0}
-        emptyTitle="No custom providers"
-        emptyDescription="Add OpenAI or Anthropic compatible endpoints to get started."
-      >
-        <Button size="sm" icon="add" onClick={() => setShowAddAnthropicCompatibleModal(true)}>Add Anthropic</Button>
-        <Button size="sm" variant="secondary" icon="add" onClick={() => setShowAddCompatibleModal(true)}>Add OpenAI</Button>
-        {[...compatibleProviders, ...anthropicCompatibleProviders].map((info) => (
-          <ProviderCardV2
-            key={info.id}
-            providerId={info.id}
-            provider={info}
-            stats={getProviderStats(info.id, "apikey")}
-            isNew={isNewProvider(info.id)}
-            onToggle={(active) => handleToggleProvider(info.id, "apikey", active)}
-          />
-        ))}
-      </ProviderSection>
+      {/* Empty states */}
+      {showSearchEmpty && (
+        <EmptyState
+          icon="search_off"
+          title={`No providers match "${searchQuery}"`}
+          description="Try a different search term or clear the filters."
+        />
+      )}
 
-      {/* Cookies Provider */}
-      <ProviderSection
-        title="Cookies Provider"
-        icon="cookie"
-        count={cookieEntries.length}
-        isExpanded={showCookies}
-        onToggle={() => setShowCookies((v) => !v)}
-        isSearching={isSearching}
-        onTestAll={() => handleBatchTest("cookie")}
-        testingMode={testingMode}
-        testModeKey="cookie"
-        hasContent={cookieEntries.length > 0}
-      >
-        {cookieEntries.map(([key, info]) => (
-          <ProviderCardV2
-            key={key}
-            providerId={key}
-            provider={info}
-            stats={getProviderStats(key, "cookie")}
-            isNoAuth={!!info.noAuth}
-            isNew={isNewProvider(key)}
-            onToggle={(active) => handleToggleProvider(key, "cookie", active)}
-          />
-        ))}
-      </ProviderSection>
+      {showNoProviders && (
+        <EmptyState
+          icon="cloud_off"
+          title="No providers yet"
+          description="Add your first provider to start routing requests."
+        />
+      )}
 
-      {/* OAuth Providers */}
-      <ProviderSection
-        title="OAuth Providers"
-        icon="lock"
-        count={oauthEntries.length}
-        isExpanded={showOauth}
-        onToggle={() => setShowOauth((v) => !v)}
-        isSearching={isSearching}
-        onTestAll={() => handleBatchTest("oauth")}
-        testingMode={testingMode}
-        testModeKey="oauth"
-        hasContent={oauthEntries.length > 0}
-      >
-        {oauthEntries.map(([key, info]) => {
-          const at = resolveStatsAuthType(info, "oauth");
-          return (
-            <ProviderCardV2
-              key={key}
-              providerId={key}
-              provider={info}
-              stats={getProviderStats(key, at)}
-              comingSoon={!!info.comingSoon}
-              isNew={isNewProvider(key)}
-              onToggle={(active) => handleToggleProvider(key, at, active)}
+      {/* Provider grid */}
+      {visibleEntries.length > 0 && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {visibleEntries.map((entry) => (
+            <ProviderTile
+              key={entry.id}
+              providerId={entry.id}
+              provider={entry}
+              stats={entry.stats}
+              isNoAuth={entry.isNoAuth}
+              comingSoon={entry.comingSoon}
+              isNew={entry.isNew}
+              testing={testingMode === entry.id}
+              onToggle={(active) => handleToggleProvider(entry.id, entry.authTypes, active)}
+              onTest={(pid) => handleBatchTest("provider", pid)}
             />
-          );
-        })}
-      </ProviderSection>
-
-      {/* Free Tier Providers */}
-      <ProviderSection
-        title="Free Tier Providers"
-        icon="redeem"
-        count={freeEntries.length + freeTierEntries.length}
-        isExpanded={showFree}
-        onToggle={() => setShowFree((v) => !v)}
-        isSearching={isSearching}
-        onTestAll={() => handleBatchTest("free")}
-        testingMode={testingMode}
-        testModeKey="free"
-        hasContent={freeEntries.length > 0 || freeTierEntries.length > 0}
-      >
-        {freeEntries.map(([key, info]) => {
-          const freeAuthTypes = key === "kiro" ? ["oauth", "apikey", "api_key"] : "oauth";
-          return (
-            <ProviderCardV2
-              key={key}
-              providerId={key}
-              provider={info}
-              stats={getProviderStats(key, freeAuthTypes)}
-              isNoAuth={!!info.noAuth}
-              isNew={isNewProvider(key)}
-              onToggle={(active) => handleToggleProvider(key, freeAuthTypes, active)}
-            />
-          );
-        })}
-        {freeTierEntries.map(([key, info]) => (
-          <ProviderCardV2
-            key={key}
-            providerId={key}
-            provider={info}
-            stats={getProviderStats(key, "apikey")}
-            isNew={isNewProvider(key)}
-            onToggle={(active) => handleToggleProvider(key, "apikey", active)}
-          />
-        ))}
-      </ProviderSection>
-
-      {/* API Key Providers */}
-      <ProviderSection
-        title="API Key Providers"
-        icon="key"
-        count={apikeyEntries.length}
-        isExpanded={showApikey}
-        onToggle={() => setShowApikey((v) => !v)}
-        isSearching={isSearching}
-        onTestAll={() => handleBatchTest("apikey")}
-        testingMode={testingMode}
-        testModeKey="apikey"
-        hasContent={apikeyEntries.length > 0}
-      >
-        {visibleApikeyEntries.map(([key, info]) => (
-          <ProviderCardV2
-            key={key}
-            providerId={key}
-            provider={info}
-            stats={getProviderStats(key, "apikey")}
-            isNew={isNewProvider(key)}
-            onToggle={(active) => handleToggleProvider(key, "apikey", active)}
-          />
-        ))}
-        {!isApikeySearching && !showAllApikey && apikeyEntries.length > 20 && (
-          <button
-            onClick={() => setShowAllApikey(true)}
-            className="flex w-full items-center justify-center gap-1.5 rounded-brand border border-dashed border-primary/40 px-3 py-2.5 text-sm font-medium text-primary transition-colors hover:border-primary hover:bg-primary/5"
-          >
-            <span className="material-symbols-outlined text-[16px]">expand_more</span>
-            Show all {apikeyEntries.length} providers
-          </button>
-        )}
-      </ProviderSection>
+          ))}
+        </div>
+      )}
 
       {/* Test Results Modal */}
       {testResults && (

--- a/src/app/(dashboard)/dashboard/quota/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/quota/components/ProviderLimits/utils.js
@@ -499,6 +499,28 @@ export function parseQuotaData(provider, data) {
         }
         break;
       }
+      case "cline":
+      case "clinepass": {
+        // Cline / ClinePass — plan usage limits (5h / weekly / monthly) given
+        // as percentUsed. used/total carry the percentage (e.g. 51/100); the
+        // table renders the remaining bar from remainingPercentage. Windows
+        // are recurring (they reset on a fixed cadence).
+        if (data.quotas) {
+          Object.entries(data.quotas).forEach(([name, quota]) => {
+            normalizedQuotas.push({
+              name,
+              used: quota.used || 0,
+              total: quota.total || 0,
+              remaining: quota.remainingPercentage,
+              remainingPercentage: quota.remainingPercentage,
+              resetAt: quota.resetAt || null,
+              recurring: true,
+              unlimited: false,
+            });
+          });
+        }
+        break;
+      }
       default:
         // Generic fallback for unknown providers
         if (data.quotas) {

--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,9 +1,56 @@
 import { NextResponse } from "next/server";
-import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
+import { getComboById, updateCombo, deleteCombo, getComboByName, getSettings, updateSettings } from "@/lib/localDb";
 import { resetComboRotation } from "open-sse/services/combo.js";
+import { VALID_NAME_REGEX } from "@/app/(dashboard)/dashboard/combos/components/helpers";
 
-// Validate combo name: only a-z, A-Z, 0-9, -, _
-const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
+// comboStrategies is keyed by combo name (see chat.js:161, CombosPageInner.js:96).
+// When a combo is renamed or deleted we MUST keep that map consistent or two
+// bugs appear: (1) rename silently reverts a fusion/swarm combo to plain
+// fallback because its strategy entry stays under the OLD name; (2) delete
+// leaves an orphan entry that a later combo reusing the same name inherits.
+//
+// These helpers build a PARTIAL patch (not a full snapshot) that is compatible
+// with the deep-merge in settingsRepo.updateSettings: a null value signals
+// deletion of that combo-name key. Sending a full snapshot would race with
+// concurrent edits to other combos (the very bug H2 fixed) AND would fail to
+// delete keys (the deep-merge only deletes when it sees `{ [key]: null }`).
+
+// Build a patch that migrates an entry from oldName → newName.
+// Returns null if there's nothing to migrate (no-op).
+function buildMigratePatch(comboStrategies, oldName, newName) {
+  if (!comboStrategies || typeof comboStrategies !== "object") return null;
+  if (oldName === newName) return null;
+  const hasOld = oldName in comboStrategies;
+  const hasNew = newName in comboStrategies;
+  if (!hasOld && !hasNew) return null;
+  const patch = {};
+  if (hasOld) {
+    // Move the entry forward ( newName wins if both exist, matching prior behavior ).
+    patch[newName] = comboStrategies[oldName];
+    // Signal deletion of the old key so the deep-merge removes it. Without this,
+    // the old entry would survive as an orphan — the exact C1 bug we're fixing.
+    patch[oldName] = null;
+  }
+  return patch;
+}
+
+// Build a patch that removes an entry by name.
+// Returns null if the entry doesn't exist (no-op).
+function buildRemovePatch(comboStrategies, name) {
+  if (!comboStrategies || typeof comboStrategies !== "object" || !(name in comboStrategies)) return null;
+  // null signals deletion to the deep-merge in updateSettings.
+  return { [name]: null };
+}
+
+// Apply a partial comboStrategies patch via the deep-merge path. No-op if the
+// transform returns null (nothing to change).
+async function patchComboStrategies(buildPatch) {
+  const settings = await getSettings();
+  const current = settings?.comboStrategies || {};
+  const patch = buildPatch(current);
+  if (!patch) return;
+  await updateSettings({ comboStrategies: patch });
+}
 
 // GET /api/combos/[id] - Get combo by ID
 export async function GET(request, { params }) {
@@ -27,24 +74,39 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    
-    // Validate name format if provided
-    if (body.name) {
+
+    // Validate name: explicit presence check (body.name === "" previously
+    // bypassed validation because "" is falsy under `if (body.name)`, storing
+    // an empty name and breaking getComboModels lookups downstream).
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || body.name.trim() === "") {
+        return NextResponse.json({ error: "Name must be a non-empty string" }, { status: 400 });
+      }
       if (!VALID_NAME_REGEX.test(body.name)) {
         return NextResponse.json({ error: "Name can only contain letters, numbers, -, _ and ." }, { status: 400 });
       }
-      
+
       // Check if name already exists (exclude current combo)
       const existing = await getComboByName(body.name);
       if (existing && existing.id !== id) {
         return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
       }
     }
-    
-    // Capture previous name to invalidate rotation state on rename
+
+    // M1: validate models is an array of strings if provided — the engine's
+    // getComboModelsFromData expects an array; a non-array value (string/object)
+    // would be stringified into the column and crash .find() at request time.
+    if (body.models !== undefined) {
+      if (!Array.isArray(body.models) || !body.models.every((m) => typeof m === "string")) {
+        return NextResponse.json({ error: "Models must be an array of strings" }, { status: 400 });
+      }
+    }
+
+    // Capture previous name to invalidate rotation state on rename + migrate
+    // comboStrategies entry so fusion/swarm config survives a rename.
     const prev = await getComboById(id);
     const combo = await updateCombo(id, body);
-    
+
     if (!combo) {
       return NextResponse.json({ error: "Combo not found" }, { status: 404 });
     }
@@ -53,7 +115,20 @@ export async function PUT(request, { params }) {
     if (prev?.name) resetComboRotation(prev.name);
     if (combo.name && combo.name !== prev?.name) resetComboRotation(combo.name);
 
-    return NextResponse.json(combo);
+    // C1 FIX: migrate comboStrategies entry when a combo is renamed, so the
+    // per-combo fusion/swarm config (judgeModel/managerModel/staffModel/
+    // auditModel) doesn't silently revert to plain fallback under the old name.
+    // Sends a partial patch ({ newName: entry, oldName: null }) compatible with
+    // the deep-merge in updateSettings — the null deletes the old key.
+    if (prev?.name && combo.name && prev.name !== combo.name) {
+      await patchComboStrategies((cs) => buildMigratePatch(cs, prev.name, combo.name));
+    }
+
+    // L3 FIX: combosRepo.updateCombo returns a `{...row, ...data}` merge that
+    // can carry arbitrary client-injected fields through to the response. Only
+    // return the canonical combo shape so we don't leak untrusted keys back.
+    const { id: _rid, name, kind, models, createdAt, updatedAt } = combo;
+    return NextResponse.json({ id, name, kind, models, createdAt, updatedAt });
   } catch (error) {
     console.log("Error updating combo:", error);
     return NextResponse.json({ error: "Failed to update combo" }, { status: 500 });
@@ -66,13 +141,20 @@ export async function DELETE(request, { params }) {
     const { id } = await params;
     const prev = await getComboById(id);
     const success = await deleteCombo(id);
-    
+
     if (!success) {
       return NextResponse.json({ error: "Combo not found" }, { status: 404 });
     }
 
     if (prev?.name) resetComboRotation(prev.name);
-    
+
+    // C1 FIX: remove the orphaned comboStrategies entry so a later combo that
+    // reuses this name doesn't silently inherit the deleted combo's strategy.
+    // Sends { [name]: null } so the deep-merge deletes the key.
+    if (prev?.name) {
+      await patchComboStrategies((cs) => buildRemovePatch(cs, prev.name));
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.log("Error deleting combo:", error);

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -1,10 +1,8 @@
 import { NextResponse } from "next/server";
 import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
+import { VALID_NAME_REGEX } from "@/app/(dashboard)/dashboard/combos/components/helpers";
 
 export const dynamic = "force-dynamic";
-
-// Validate combo name: only a-z, A-Z, 0-9, -, _
-const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
 
 // GET /api/combos - Get all combos
 export async function GET() {
@@ -23,13 +21,20 @@ export async function POST(request) {
     const body = await request.json();
     const { name, models, kind } = body;
 
-    if (!name) {
+    if (!name || typeof name !== "string" || name.trim() === "") {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
-    // Validate name format
+    // Validate name format (single source of truth — imported from helpers)
     if (!VALID_NAME_REGEX.test(name)) {
       return NextResponse.json({ error: "Name can only contain letters, numbers, -, _ and ." }, { status: 400 });
+    }
+
+    // M1 FIX: validate models is an array of strings. A non-array (string or
+    // object) would be stringified into the DB column and crash the engine's
+    // getComboModelsFromData which expects an array and calls .find() on it.
+    if (models !== undefined && (!Array.isArray(models) || !models.every((m) => typeof m === "string"))) {
+      return NextResponse.json({ error: "Models must be an array of strings" }, { status: 400 });
     }
 
     // Check if name already exists
@@ -38,7 +43,7 @@ export async function POST(request) {
       return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
     }
 
-    const combo = await createCombo({ name, models: models || [], kind: kind || null });
+    const combo = await createCombo({ name, models: Array.isArray(models) ? models : [], kind: kind || null });
 
     return NextResponse.json(combo, { status: 201 });
   } catch (error) {

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -114,6 +114,27 @@ export async function updateSettings(updates) {
     const row = db.get(`SELECT data FROM settings WHERE id = 1`);
     const current = row ? parseJson(row.data, {}) : {};
     next = { ...current, ...updates };
+
+    // Deep-merge `comboStrategies`: it is a map keyed by combo name where each
+    // entry holds per-combo config (fallbackStrategy/judgeModel/managerModel/
+    // fusionTuning/swarmTuning). A shallow top-level merge would let one
+    // writer's full snapshot clobber every other combo's entry — a classic
+    // lost-update race when two browser tabs edit different combos. Merge at
+    // the combo-name level instead: incoming entries win, others are preserved.
+    // Deletions are signalled by sending `{ [comboName]: null }`.
+    if (updates && typeof updates.comboStrategies === "object" && !Array.isArray(updates.comboStrategies)) {
+      const baseCs = (current.comboStrategies && typeof current.comboStrategies === "object") ? current.comboStrategies : {};
+      const mergedCs = { ...baseCs };
+      for (const [name, entry] of Object.entries(updates.comboStrategies)) {
+        if (entry === null) {
+          delete mergedCs[name];
+        } else {
+          mergedCs[name] = { ...(mergedCs[name] || {}), ...(entry || {}) };
+        }
+      }
+      next.comboStrategies = mergedCs;
+    }
+
     db.run(
       `INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`,
       [stringifyJson(next)]

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -27,6 +27,18 @@ import { recordBreakerSuccess, recordBreakerFailure, isRetryableFailure, release
 import { recordHealthSample } from "open-sse/services/healthMonitor.js";
 import { getApiKeyByKey } from "@/lib/localDb";
 
+// M2 FIX: normalize a combo strategy string to a known value. Accepts case
+// variants + surrounding whitespace ("FUSION", "Round-Robin ", " Swarm ") and
+// maps unknown values to "fallback" so a typo or client-injected junk never
+// silently mis-dispatches. The previous exact-case compares meant "FUSION"
+// fell through to handleComboChat as plain fallback with no indication.
+const KNOWN_STRATEGIES = new Set(["fallback", "round-robin", "fusion", "swarm"]);
+function normalizeStrategy(raw) {
+  if (typeof raw !== "string") return "fallback";
+  const s = raw.trim().toLowerCase();
+  return KNOWN_STRATEGIES.has(s) ? s : "fallback";
+}
+
 /**
  * Handle chat completion request
  * Supports: OpenAI, Claude, Gemini, OpenAI Responses API formats
@@ -160,7 +172,7 @@ export async function handleChat(request, clientRawRequest = null) {
     // Check for combo-specific strategy first, fallback to global
     const comboStrategies = settings.comboStrategies || {};
     const comboSpecificStrategy = comboStrategies[modelStr]?.fallbackStrategy;
-    const comboStrategy = comboSpecificStrategy || settings.comboStrategy || "fallback";
+    const comboStrategy = normalizeStrategy(comboSpecificStrategy || settings.comboStrategy || "fallback");
 
     if (comboStrategy === "fusion") {
       log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: fusion)`);
@@ -173,7 +185,7 @@ export async function handleChat(request, clientRawRequest = null) {
             const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
             cleanRawReq = { ...clientRawRequest, body: cleanBody };
           }
-          return handleSingleModelChat(b, m, cleanRawReq, request, apiKey);
+          return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, { skipBreaker: isPanel });
         },
         log,
         comboName: modelStr,
@@ -182,7 +194,7 @@ export async function handleChat(request, clientRawRequest = null) {
       });
     }
 
-    const comboStickyLimit = settings.comboStickyLimit;
+    const comboStickyLimit = settings.comboStickyRoundRobinLimit;
     if (comboStrategy === "swarm") {
       log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: swarm)`);
       const swarmCfg = comboStrategies[modelStr] || {};
@@ -195,7 +207,7 @@ export async function handleChat(request, clientRawRequest = null) {
             const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
             cleanRawReq = { ...clientRawRequest, body: cleanBody };
           }
-          return handleSingleModelChat(b, m, cleanRawReq, request, apiKey);
+          return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, { skipBreaker: isPanel });
         },
         log,
         comboName: modelStr,
@@ -216,7 +228,8 @@ export async function handleChat(request, clientRawRequest = null) {
       log,
       comboName: modelStr,
       comboStrategy,
-      comboStickyLimit
+      comboStickyLimit,
+      breakerSettings: settings,
     });
   }
 
@@ -227,7 +240,7 @@ export async function handleChat(request, clientRawRequest = null) {
 /**
  * Handle single model chat request
  */
-async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null) {
+async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null, opts = {}) {
   const modelInfo = await getModelInfo(modelStr);
 
   // If provider is null, this might be a combo name - check and handle
@@ -238,7 +251,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       // Check for combo-specific strategy first, fallback to global
       const comboStrategies = chatSettings.comboStrategies || {};
       const comboSpecificStrategy = comboStrategies[modelStr]?.fallbackStrategy;
-      const comboStrategy = comboSpecificStrategy || chatSettings.comboStrategy || "fallback";
+      const comboStrategy = normalizeStrategy(comboSpecificStrategy || chatSettings.comboStrategy || "fallback");
 
       if (comboStrategy === "fusion") {
         log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: fusion)`);
@@ -251,7 +264,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
               const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
               cleanRawReq = { ...clientRawRequest, body: cleanBody };
             }
-            return handleSingleModelChat(b, m, cleanRawReq, request, apiKey);
+            return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, { skipBreaker: isPanel });
           },
           log,
           comboName: modelStr,
@@ -273,7 +286,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
               const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
               cleanRawReq = { ...clientRawRequest, body: cleanBody };
             }
-            return handleSingleModelChat(b, m, cleanRawReq, request, apiKey);
+            return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, { skipBreaker: isPanel });
           },
           log,
           comboName: modelStr,
@@ -294,7 +307,8 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         log,
         comboName: modelStr,
         comboStrategy,
-        comboStickyLimit
+        comboStickyLimit,
+        breakerSettings: chatSettings,
       });
     }
     log.warn("CHAT", "Invalid model format", { model: modelStr });
@@ -403,7 +417,12 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
 
     if (result.success) {
       const latencyMs = Date.now() - attemptStart;
-      recordBreakerSuccess(provider, chatSettings);
+      // M6 FIX: panel calls (fusion/swarm fan-out) share the per-provider
+      // breaker with non-combo traffic. Recording failures here would let a
+      // flaky panel model trip the breaker and block single-model requests
+      // to the same provider. skipBreaker isolates panel outcomes so only the
+      // final user-facing call (judge/synthesis/direct) affects breaker state.
+      if (!opts.skipBreaker) recordBreakerSuccess(provider, chatSettings);
       recordHealthSample(provider, { success: true, latencyMs }, chatSettings);
       return result.response;
     }
@@ -417,7 +436,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Record health + circuit breaker for retryable failures only.
     const latencyMs = Date.now() - attemptStart;
     recordHealthSample(provider, { success: false, latencyMs, status: result.status }, chatSettings);
-    if (isRetryableFailure(result.status)) {
+    if (isRetryableFailure(result.status) && !opts.skipBreaker) {
       recordBreakerFailure(provider, result.status, chatSettings);
     }
 

--- a/tests/unit/sanitize-html.test.js
+++ b/tests/unit/sanitize-html.test.js
@@ -2,89 +2,151 @@
  * Adversarial self-check for the DOMPurify-based sanitizeHtml.
  *
  * Asserts that attack vectors which bypassed the previous regex-based
- * sanitizer are now neutralized. Run with: node tests/unit/sanitize-html.test.js
- * (or as a plain script — it throws on failure, prints PASS on success).
+ * sanitizer are now neutralized. Run under vitest:
+ *   npx vitest run tests/unit/sanitize-html.test.js
+ * Or as a plain script (no vitest):
+ *   node tests/unit/sanitize-html.test.js
  *
- * Note: DOMPurify requires a DOM. Under Node we provide one via jsdom if
- * available; the test harness (vitest with environment:'jsdom') supplies it
- * automatically. When run as a bare script without jsdom we skip gracefully.
+ * DOMPurify requires a DOM. Under vitest with environment:'jsdom' the harness
+ * supplies one; the project's vitest config uses environment:'node', so this
+ * file bootstraps jsdom itself before importing sanitizeHtml. When run as a
+ * bare script without jsdom we skip gracefully.
+ *
+ * Dual-mode: when vitest globals (describe/it/expect) are present the cases
+ * are registered through the framework so failures surface in the test
+ * report. Otherwise we fall back to a console-driven runner that still
+ * reports every case and exits non-zero on failure.
  */
 
-let sanitizeHtml;
-let skipped = false;
+const CASES = [
+  // [name, input, predicate(out) => true if SAFE]
+  ["strips <script>", '<p>hi</p><script>alert(1)</script>', (o) => !o.includes("<script")],
+  // Nested-tag evasion: safe if no executable markup remains. The alert text
+  // surviving as inert, HTML-encoded plain text is correct behavior.
+  ["blocks nested-tag bypass <scr<script>ipt>", "<scr<script>ipt>alert(1)</scr</script>ipt>", (o) => !/<script/i.test(o) && !/<[a-z]+[^>]*on\w+=/i.test(o)],
+  ["strips onerror handler", '<img src=x onerror="alert(1)">', (o) => !/onerror/i.test(o)],
+  ["strips unquoted onerror", "<img src=x onerror=alert(1)>", (o) => !/onerror/i.test(o)],
+  ["strips entity-encoded handler", '<img src=x &#111;nerror="alert(1)">', (o) => !/onerror=/i.test(o)],
+  ["strips onclick on div", '<div onclick="alert(1)">x</div>', (o) => !/onclick/i.test(o)],
+  ["blocks javascript: href", '<a href="javascript:alert(1)">x</a>', (o) => !/javascript:/i.test(o)],
+  ["blocks entity-encoded javascript:", '<a href="&#106;avascript:alert(1)">x</a>', (o) => !/javascript:/i.test(o)],
+  ["blocks vbscript:", '<a href="vbscript:msgbox(1)">x</a>', (o) => !/vbscript:/i.test(o)],
+  ["blocks svg data: in img src", '<img src="data:image/svg+xml,<svg onload=alert(1)>">', (o) => !/onload/i.test(o) && !/svg/i.test(o)],
+  ["keeps raster data: images", '<img src="data:image/png;base64,iVBORw0KGgo=">', (o) => /data:image\/png/.test(o)],
+  ["strips <style> tag", '<style>body{background:url(http://evil)}</style><p>x</p>', (o) => !/<style/i.test(o)],
+  ["strips style attribute", '<p style="background:url(javascript:alert(1))">x</p>', (o) => !/style=/i.test(o)],
+  ["strips <form>", '<form action="http://evil"><input name=p></form>', (o) => !/<form/i.test(o) && !/<input/i.test(o)],
+  ["strips <iframe>", '<iframe src="http://evil"></iframe>', (o) => !/<iframe/i.test(o)],
+  ["strips <object>", '<object data="http://evil"></object>', (o) => !/<object/i.test(o)],
+  ["strips <svg onload>", '<svg onload="alert(1)"><circle/></svg>', (o) => !/onload/i.test(o) && !/alert\(1\)/.test(o)],
+  ["adds noopener to links", '<a href="https://ok.example">x</a>', (o) => /rel="noopener noreferrer"/.test(o) && /target="_blank"/.test(o)],
+  ["keeps safe markdown html", '<p>Hello <strong>world</strong></p>', (o) => o.includes("<strong>world</strong>")],
+  ["keeps code blocks", '<pre><code class="language-js">const a = 1;</code></pre>', (o) => o.includes("const a = 1;")],
+  ["empty string safe", "", (o) => o === ""],
+  ["non-string safe", null, (o) => o === ""],
+];
 
-try {
-  // Prefer a real browser-like DOM if the harness provides one (vitest jsdom).
+// --- Bootstrap a DOM for DOMPurify if the host doesn't already provide one --
+async function loadSanitizeHtml() {
   if (typeof window === "undefined" || typeof window.DOMParser === "undefined") {
     let JSDOM;
     try {
       ({ JSDOM } = await import("jsdom"));
     } catch {
-      skipped = true;
-      console.log("SKIP: jsdom not available — install jsdom or run under vitest with environment 'jsdom'.");
+      return { skipped: true, reason: "jsdom not available — install jsdom or run under vitest with environment 'jsdom'." };
     }
-    if (!skipped) {
-      const dom = new JSDOM("<!doctype html><html><body></body></html>");
-      globalThis.window = dom.window;
-      globalThis.document = dom.window.document;
-      globalThis.DOMParser = dom.window.DOMParser;
-    }
+    const dom = new JSDOM("<!doctype html><html><body></body></html>");
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.DOMParser = dom.window.DOMParser;
   }
-  if (!skipped) {
-    ({ sanitizeHtml } = await import("../../src/shared/utils/sanitizeHtml.js"));
-  }
-} catch (err) {
-  console.error("SETUP FAIL:", err.message);
-  process.exit(1);
+  const { sanitizeHtml } = await import("../../src/shared/utils/sanitizeHtml.js");
+  return { sanitizeHtml, skipped: false };
 }
 
-if (!skipped) {
-  const cases = [
-    // [name, input, predicate(out) => true if SAFE]
-    ["strips <script>", '<p>hi</p><script>alert(1)</script>', (o) => !o.includes("<script")],
-    // Nested-tag evasion: safe if no executable markup remains. The alert text
-    // surviving as inert, HTML-encoded plain text is correct behavior.
-    ["blocks nested-tag bypass <scr<script>ipt>", "<scr<script>ipt>alert(1)</scr</script>ipt>", (o) => !/<script/i.test(o) && !/<[a-z]+[^>]*on\w+=/i.test(o)],
-    ["strips onerror handler", '<img src=x onerror="alert(1)">', (o) => !/onerror/i.test(o)],
-    ["strips unquoted onerror", "<img src=x onerror=alert(1)>", (o) => !/onerror/i.test(o)],
-    ["strips entity-encoded handler", '<img src=x &#111;nerror="alert(1)">', (o) => !/onerror=/i.test(o)],
-    ["strips onclick on div", '<div onclick="alert(1)">x</div>', (o) => !/onclick/i.test(o)],
-    ["blocks javascript: href", '<a href="javascript:alert(1)">x</a>', (o) => !/javascript:/i.test(o)],
-    ["blocks entity-encoded javascript:", '<a href="&#106;avascript:alert(1)">x</a>', (o) => !/javascript:/i.test(o)],
-    ["blocks vbscript:", '<a href="vbscript:msgbox(1)">x</a>', (o) => !/vbscript:/i.test(o)],
-    ["blocks svg data: in img src", '<img src="data:image/svg+xml,<svg onload=alert(1)>">', (o) => !/onload/i.test(o) && !/svg/i.test(o)],
-    ["keeps raster data: images", '<img src="data:image/png;base64,iVBORw0KGgo=">', (o) => /data:image\/png/.test(o)],
-    ["strips <style> tag", '<style>body{background:url(http://evil)}</style><p>x</p>', (o) => !/<style/i.test(o)],
-    ["strips style attribute", '<p style="background:url(javascript:alert(1))">x</p>', (o) => !/style=/i.test(o)],
-    ["strips <form>", '<form action="http://evil"><input name=p></form>', (o) => !/<form/i.test(o) && !/<input/i.test(o)],
-    ["strips <iframe>", '<iframe src="http://evil"></iframe>', (o) => !/<iframe/i.test(o)],
-    ["strips <object>", '<object data="http://evil"></object>', (o) => !/<object/i.test(o)],
-    ["strips <svg onload>", '<svg onload="alert(1)"><circle/></svg>', (o) => !/onload/i.test(o) && !/alert\(1\)/.test(o)],
-    ["adds noopener to links", '<a href="https://ok.example">x</a>', (o) => /rel="noopener noreferrer"/.test(o) && /target="_blank"/.test(o)],
-    ["keeps safe markdown html", '<p>Hello <strong>world</strong></p>', (o) => o.includes("<strong>world</strong>")],
-    ["keeps code blocks", '<pre><code class="language-js">const a = 1;</code></pre>', (o) => o.includes("const a = 1;")],
-    ["empty string safe", "", (o) => o === ""],
-    ["non-string safe", null, (o) => o === ""],
-  ];
+// --- vitest path: register cases through the framework -----------------------
+// Detect vitest by checking for its globals (config sets globals:true). Using
+// dynamic property lookup keeps this file loadable in plain-node mode too.
+const vitestDescribe = globalThis.describe;
+const vitestIt = globalThis.it;
+const vitestExpect = globalThis.expect;
+const vitestBeforeAll = globalThis.beforeAll;
+const isVitest =
+  typeof vitestDescribe === "function" &&
+  typeof vitestIt === "function" &&
+  typeof vitestExpect === "function";
 
-  let failures = 0;
-  for (const [name, input, isSafe] of cases) {
-    let out;
+if (isVitest) {
+  vitestDescribe("sanitizeHtml (DOMPurify-based)", () => {
+    // Hoist the resolved sanitizeHtml into a closure the test cases can read.
+    // Top-level await in the describe body isn't supported uniformly across
+    // vitest versions, so we resolve it in a beforeAll hook.
+    let sanitizeHtml = null;
+    let setupError = null;
+
+    // beforeAll is a global under vitest's globals:true config. Guard the call
+    // so the file still loads if a future vitest version drops it.
+    if (typeof vitestBeforeAll === "function") {
+      vitestBeforeAll(async () => {
+        try {
+          const r = await loadSanitizeHtml();
+          sanitizeHtml = r.sanitizeHtml || null;
+        } catch (err) {
+          setupError = err;
+        }
+      });
+    }
+
+    vitestIt.each(CASES)("%s", async (_name, input, isSafe) => {
+      // Lazy fallback if beforeAll never ran (e.g. vitest version mismatch):
+      // load on first use. Subsequent calls reuse the cached result.
+      if (!sanitizeHtml && !setupError) {
+        const r = await loadSanitizeHtml();
+        sanitizeHtml = r.sanitizeHtml || null;
+      }
+      if (setupError) throw setupError;
+      if (!sanitizeHtml) {
+        // jsdom unavailable — record as skipped rather than masking as pass.
+        vitestExpect(sanitizeHtml, "jsdom unavailable; sanitizeHtml did not load").toBeTruthy();
+        return;
+      }
+      const out = sanitizeHtml(input);
+      vitestExpect(isSafe(out)).toBe(true);
+    });
+  });
+} else {
+  // --- standalone-script path: console runner with full case reporting -----
+  (async () => {
     try {
-      out = sanitizeHtml(input);
-    } catch (err) {
-      console.log(`FAIL  ${name} — threw: ${err.message}`);
-      failures++;
-      continue;
-    }
-    if (isSafe(out)) {
-      console.log(`PASS  ${name}`);
-    } else {
-      console.log(`FAIL  ${name}\n      in : ${JSON.stringify(input)}\n      out: ${JSON.stringify(out)}`);
-      failures++;
-    }
-  }
+      const { sanitizeHtml, skipped, reason } = await loadSanitizeHtml();
+      if (skipped) {
+        console.log("SKIP:", reason);
+        process.exit(0);
+      }
 
-  console.log(failures === 0 ? `\n✅ ALL ${cases.length} CASES PASS` : `\n❌ ${failures}/${cases.length} FAILURES`);
-  process.exit(failures === 0 ? 0 : 1);
+      let failures = 0;
+      for (const [name, input, isSafe] of CASES) {
+        let out;
+        try {
+          out = sanitizeHtml(input);
+        } catch (err) {
+          console.log(`FAIL  ${name} — threw: ${err.message}`);
+          failures++;
+          continue;
+        }
+        if (isSafe(out)) {
+          console.log(`PASS  ${name}`);
+        } else {
+          console.log(`FAIL  ${name}\n      in : ${JSON.stringify(input)}\n      out: ${JSON.stringify(out)}`);
+          failures++;
+        }
+      }
+
+      console.log(failures === 0 ? `\n✅ ALL ${CASES.length} CASES PASS` : `\n❌ ${failures}/${CASES.length} FAILURES`);
+      process.exit(failures === 0 ? 0 : 1);
+    } catch (err) {
+      console.error("SETUP FAIL:", err.message);
+      process.exit(1);
+    }
+  })();
 }


### PR DESCRIPTION
…, breaker pre-filter, Providers + Provider detail page redesign

Features:
- Cline + ClinePass Quota Tracker (shared getClineUsage handler)
- Breaker-aware combo pre-filter (isBreakerBlocking + filterBreakerOpenModels)
- Providers list page redesign (unified grid + filter chips + rich tiles + KPIs)
- Provider detail page redesign (God Component split into 4 components)

Fixes (combo engine — 4 audit rounds):
- C1 Critical: body_global race condition in swarm (cross-request leak)
- C2 Critical: releaseBreakerProbe ReferenceError (breaker stuck forever)
- C1+H2 Critical: orphaned comboStrategies on rename/delete
- H1-H5: stickyLimit key, lost-update race, stale modal state, closure-models, empty-name bypass
- M1-M6: models validation, case-insensitive strategy, stream flag, null-guard, silent delete, breaker pollution
- L1-L9: distribution whitelist, PUT shape, stale role fields, regex dedup, fetch cleanup

Code review:
- GitHub /responses proactive routing
- xAI unused U import removed
- sanitize-html test idiomatic vitest

Bumps package.json + cli/package.json to 0.7.5