### PR TITLE
Add forensic observability for empty responses

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -18,6 +18,8 @@ import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { getExecutor } from "../executors/index.js";
+import REGISTRY from "../providers/registry/index.js";
+import { createForensicId } from "../utils/forensicIds.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./chatCore/requestDetail.js";
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
@@ -86,7 +88,7 @@ function buildTransportAttempt(status, { abortSeen = false } = {}) {
  *   return path carries an explicit `success` boolean so callers branch on one
  *   contract (see buildChatResult / createErrorResult in utils/error.js).
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking, semanticCacheEnabled, semanticCacheThreshold, pxpipeEnabled, pxpipeDir, pxpipeMinChars, pxpipeTimeoutMs, externalSignal, opencodeIdentity, comboContext }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking, semanticCacheEnabled, semanticCacheThreshold, pxpipeEnabled, pxpipeDir, pxpipeMinChars, pxpipeTimeoutMs, externalSignal, opencodeIdentity, comboContext, forensicMeta }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -363,6 +365,22 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (passthrough && clientTool === "claude") anchorClaudeCache(translatedBody);
 
   const executor = getExecutor(provider);
+  const executorIdentity = {
+    implementation: executor?.constructor?.name || "unknown",
+    dispatch: REGISTRY.some((entry) => entry.id === provider) && executor?.constructor?.name !== "DefaultExecutor"
+      ? "specialized_registry"
+      : "default_executor",
+  };
+  const forensic = {
+    ...forensicMeta,
+    requestId: forensicMeta?.requestId || createForensicId("req"),
+    attemptId: forensicMeta?.attemptId || createForensicId("attempt"),
+    physicalProviderId: provider,
+    physicalProviderAlias: forensicMeta?.physicalProviderAlias || PROVIDER_ID_TO_ALIAS[provider] || provider,
+    physicalProviderName: REGISTRY.find((entry) => entry.id === provider)?.display?.name || provider,
+    physicalModel: model,
+    executor: executorIdentity,
+  };
   trackPendingRequest(model, provider, connectionId, true);
   appendRequestLog({ model, provider, connectionId, status: "PENDING" }).catch(() => { });
 
@@ -540,16 +558,20 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     if (recovered) {
       reqLogger.logTargetRequest(providerUrl, providerHeaders, finalBody);
     } else {
-      appendRequestLog({ model, provider, connectionId, status: `FAILED ${error.name === "AbortError" ? 499 : HTTP_STATUS.BAD_GATEWAY}` }).catch(() => { });
+      const networkStatus = error.name === "AbortError" ? 499 : HTTP_STATUS.BAD_GATEWAY;
+      appendRequestLog({ model, provider, connectionId, status: `FAILED ${networkStatus}` }).catch(() => { });
       saveRequestDetail(buildRequestDetail({
         provider, model, connectionId,
         latency: { ttft: 0, total: Date.now() - requestStartTime },
         tokens: { prompt_tokens: 0, completion_tokens: 0 },
         request: extractRequestConfig(body, stream),
         providerRequest: translatedBody || null,
-        response: { error: error.message || String(error), status: error.name === "AbortError" ? 499 : 502, thinking: null },
+        response: { error: error.message || String(error), status: networkStatus, thinking: null },
         status: "error",
-        combo: comboContext
+        combo: comboContext,
+        correlation: forensic,
+        transport: { status: networkStatus, contentType: null, streamMode: stream ? "streaming" : "non-streaming" },
+        canonicalAttempt: buildTransportAttempt(networkStatus, { abortSeen: networkStatus === 499 }),
       })).catch(() => { });
 
       const errMsg = formatProviderError(error, provider, model, HTTP_STATUS.BAD_GATEWAY);
@@ -604,7 +626,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
           providerRequest: finalBody || translatedBody || null,
           response: { error: message, status: statusCode, thinking: null },
           status: "error",
-          combo: comboContext
+          combo: comboContext,
+          correlation: forensic,
+          transport: { status: statusCode, contentType: providerResponse.headers.get("content-type") || null, streamMode: stream ? "streaming" : "non-streaming" },
+          canonicalAttempt: buildTransportAttempt(statusCode),
         })).catch(() => { });
 
         const errMsg = formatProviderError(new Error(message), provider, model, statusCode);
@@ -624,7 +649,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
         providerRequest: finalBody || translatedBody || null,
         response: { error: message, status: statusCode, thinking: null },
         status: "error",
-        combo: comboContext
+        combo: comboContext,
+        correlation: forensic,
+        transport: { status: statusCode, contentType: providerResponse.headers.get("content-type") || null, streamMode: stream ? "streaming" : "non-streaming" },
+        canonicalAttempt: buildTransportAttempt(statusCode),
       })).catch(() => { });
 
       const errMsg = formatProviderError(new Error(message), provider, model, statusCode);
@@ -635,12 +663,13 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   const sharedCtx = {
-    provider, model, body, stream, translatedBody, finalBody, requestStartTime,
+    provider, model, body, stream, sourceFormat, targetFormat, translatedBody, finalBody, requestStartTime,
     connectionId, apiKey, clientRawRequest, onRequestSuccess, savedTokens,
     savedTokensByMechanism, savedBytesByMechanism,
     cavemanActive: !!cavemanEnabled, ponytailActive: !!ponytailEnabled,
     retryCount: executorRetryCount,
     combo: comboContext,
+    forensic,
   };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
@@ -652,6 +681,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       // G2-D.2: executor transport retries ride the envelope (shared retry
       // accounting with the semantic retry gate). Adapters keep their shape.
       if (result?.retryCount == null) result.retryCount = executorRetryCount;
+      if (result) result.correlation = forensic;
       streamController.handleComplete();
       return result;
     }
@@ -663,13 +693,14 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     // G2-D.2: executor transport retries ride the envelope (shared retry
     // accounting with the semantic retry gate). Adapters keep their own shape.
     if (result?.retryCount == null) result.retryCount = executorRetryCount;
+    if (result) result.correlation = forensic;
     streamController.handleComplete();
     return result;
   }
 
   // Streaming response
-  const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
-  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId });
+  const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx, sourceFormat, targetFormat, forensic });
+  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId, forensic });
 }
 
 export function isTokenExpiringSoon(expiresAt, bufferMs = 5 * 60 * 1000) {

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -202,7 +202,7 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 /**
  * Handle non-streaming response from provider.
  */
-export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, savedTokens, savedTokensByMechanism, savedBytesByMechanism, cavemanActive, ponytailActive, retryCount, combo }) {
+export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, savedTokens, savedTokensByMechanism, savedBytesByMechanism, cavemanActive, ponytailActive, retryCount, combo, forensic }) {
   trackDone();
   const contentType = providerResponse.headers.get("content-type") || "";
   let responseBody;
@@ -353,9 +353,11 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     status: mapCanonicalAttemptToRequestStatus(canonicalAttempt),
     combo
   }, {
-    endpoint: clientRawRequest?.endpoint || null,
-    canonicalAttempt,
-  })).catch(err => {
+        endpoint: clientRawRequest?.endpoint || null,
+        transport: { status: providerResponse.status, contentType, streamMode: "non-streaming" },
+        correlation: forensic || null,
+        canonicalAttempt,
+      })).catch(err => {
     console.error("[RequestDetail] Failed to save:", err.message);
   });
 

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -59,6 +59,7 @@ export function extractUsageFromResponse(responseBody) {
 
 export function buildRequestDetail(base, overrides = {}) {
   return {
+    ...(base.id ? { id: base.id } : {}),
     provider: base.provider || "unknown",
     model: base.model || "unknown",
     connectionId: base.connectionId || undefined,

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -110,7 +110,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel, { onMalformedLin
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
  */
-export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog, savedTokens, savedTokensByMechanism, savedBytesByMechanism, cavemanActive, ponytailActive, retryCount, combo }) {
+export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog, savedTokens, savedTokensByMechanism, savedBytesByMechanism, cavemanActive, ponytailActive, retryCount, combo, forensic }) {
   const contentType = providerResponse.headers.get("content-type") || "";
   const isSSE = contentType.includes("text/event-stream") || (contentType === "" && isResponsesProvider(provider));
   if (!isSSE) return null; // not handled here
@@ -118,7 +118,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
   trackDone();
 
   const ctx = {
-    provider, model, connectionId, combo,
+    provider, model, connectionId, combo, forensic,
     request: extractRequestConfig(body, stream),
     providerRequest: finalBody || translatedBody || null
   };
@@ -180,6 +180,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         status: mapCanonicalAttemptToRequestStatus(canonicalAttempt)
       }, {
         endpoint: clientRawRequest?.endpoint || null,
+        transport: { status: providerResponse.status, contentType, streamMode: "forced-sse-json", sourceFormat, targetFormat: "openai" },
+        correlation: forensic || null,
         canonicalAttempt,
       })).catch(() => {});
 
@@ -267,6 +269,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         status: "error",
       }, {
         endpoint: clientRawRequest?.endpoint || null,
+        transport: { status: providerResponse.status, contentType, streamMode: "forced-sse-json", sourceFormat, targetFormat: "openai" },
+        correlation: forensic || null,
         canonicalAttempt,
       })).catch(() => {});
       return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request", undefined, { canonicalAttempt });

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -51,7 +51,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 /**
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
-export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId, savedTokens, combo }) {
+export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId, savedTokens, combo, forensic }) {
   if (onRequestSuccess) {
     Promise.resolve()
       .then(onRequestSuccess)
@@ -131,8 +131,14 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
       providerResponse: "[Streaming - raw response not captured]",
       response: { content: "[Stream terminated before completion]", thinking: null, type: "streaming" },
       status,
-      combo
-    }, { id: streamDetailId, canonicalAttempt: attempt })).catch(err => {
+      combo,
+    }, {
+      id: streamDetailId,
+      correlation: forensic || null,
+      transport: { status: providerResponse.status, contentType: upstreamContentType, streamMode: "streaming", sourceFormat, targetFormat },
+      canonicalAttempt: attempt,
+      streamObservability: pickStreamObservability(streamState, { sourceFormat, targetFormat, mode: "streaming" }),
+    })).catch(err => {
       console.error("[RequestDetail] Failed to finalize streaming request:", err.message);
     });
     console.log(`[RequestDetail] lifecycle: streaming → ${status} | provider=${provider} | model=${model} | reason=${terminationReason} | classification=${attempt.classification ?? "null"}${combo ? ` | combo=${combo.id || "custom"}` : ""}`);
@@ -187,8 +193,13 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
     providerResponse: "[Streaming - raw response not captured]",
     response: { content: "[Streaming in progress...]", thinking: null, type: "streaming" },
     status: REQUEST_DETAIL_STREAMING_STATUS,
-    combo
-  }, { id: streamDetailId })).catch(err => {
+      combo,
+    }, {
+      id: streamDetailId,
+      correlation: forensic || null,
+      transport: { status: providerResponse.status, contentType: upstreamContentType, streamMode: "streaming", sourceFormat, targetFormat },
+      streamObservability: pickStreamObservability(streamState, { sourceFormat, targetFormat, mode: "streaming" }),
+    })).catch(err => {
     console.error("[RequestDetail] Failed to save streaming request:", err.message);
   });
 
@@ -206,9 +217,17 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
  * Wave 2/2 adds the derived semantic fields (usableOutput / logicalSuccess /
  * outcome) — informational, consulted by no production behavior.
  */
-function pickStreamObservability(state) {
+function pickStreamObservability(state, meta = {}) {
   if (!state) return undefined;
+  const hasCounters = Number.isFinite(state.recvLines) || Number.isFinite(state.dataLines) || Number.isFinite(state.eventLines) || Number.isFinite(state.emitted);
   return {
+    sourceFormat: meta.sourceFormat || null,
+    targetFormat: meta.targetFormat || null,
+    mode: meta.mode || "streaming",
+    recvLines: hasCounters && Number.isFinite(state.recvLines) ? state.recvLines : null,
+    dataLines: hasCounters && Number.isFinite(state.dataLines) ? state.dataLines : null,
+    eventLines: hasCounters && Number.isFinite(state.eventLines) ? state.eventLines : null,
+    emitted: hasCounters && Number.isFinite(state.emitted) ? state.emitted : null,
     streamStarted: !!state.streamStarted,
     hasText: !!state.hasText,
     hasReasoning: !!state.hasReasoning,
@@ -230,7 +249,7 @@ function pickStreamObservability(state) {
 /**
  * Build onStreamComplete callback for streaming usage tracking.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, savedTokens, savedTokensByMechanism, savedBytesByMechanism, cavemanActive, ponytailActive, retryCount, combo }) {
+export function buildOnStreamComplete({ provider, model, sourceFormat, targetFormat, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, savedTokens, savedTokensByMechanism, savedBytesByMechanism, cavemanActive, ponytailActive, retryCount, combo, forensic }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
   // Wave 2: the transform appends the observational streamState as the 4th
@@ -242,7 +261,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     };
     const safeContent = contentObj?.content || "[Empty streaming response]";
     const safeThinking = contentObj?.thinking || null;
-    const observability = pickStreamObservability(streamState);
+    const observability = pickStreamObservability(streamState, { sourceFormat, targetFormat, mode: "streaming" });
     // Canonical attempt: pure derivation composed with transport status at
     // the integration boundary (status only — body never touched). This is
     // the FINAL outcome evidence for the request detail: the persisted status
@@ -262,9 +281,11 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
       providerResponse: safeContent,
       response: { content: safeContent, thinking: safeThinking, type: "streaming" },
       status: finalStatus,
-      combo
+      combo,
     }, {
       id: streamDetailId,
+      correlation: forensic || null,
+      transport: { status: transportStatus ?? null, contentType: null, streamMode: "streaming" },
       ...(observability ? { streamObservability: observability } : {}),
       ...(canonicalAttempt ? { canonicalAttempt } : {}),
     })).catch(err => {

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -19,6 +19,8 @@ import {
   markRunError,
   markRunComplete,
 } from "./smartRoutingTelemetry.js";
+import { saveRequestDetail } from "@/lib/usageDb.js";
+import { mapCanonicalAttemptToRequestStatus } from "../utils/requestDetailStatus.js";
 
 // Hard capabilities = input modalities; missing one drops request data (e.g. image
 // stripped). Must be prioritized. Soft (e.g. search) only degrades a feature.
@@ -420,19 +422,53 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
   let lastError = null;
   let earliestRetryAfter = null;
   let lastStatus = null;
+  const persistAttempt = ({ forensic, result = null, attempt = null, fallbackDecision }) => {
+    if (!forensic?.attemptId || !forensic?.requestId) return;
+    const record = {
+      ...forensic,
+      status: result?.status ?? result?.response?.status ?? null,
+      classification: attempt?.classification || null,
+      reason: attempt?.reason || null,
+      outcome: attempt?.outcome || null,
+      logicalSuccess: attempt?.logicalSuccess === true,
+      completionState: attempt?.completionState || null,
+      completionType: attempt?.completionType || null,
+      terminalState: attempt?.terminalState || null,
+      terminalType: attempt?.terminalType || null,
+      finishReason: attempt?.finishReason || null,
+      usableOutput: attempt?.usableOutput === true,
+        fallbackDecision,
+        streamObservability: result?.streamObservability || null,
+        canonicalAttempt: attempt || null,
+    };
+    saveRequestDetail({
+      id: forensic.requestId,
+      provider: forensic.physicalProviderId || null,
+      model: forensic.physicalModel || null,
+      status: attempt
+        ? mapCanonicalAttemptToRequestStatus(attempt)
+        : (record.status >= 400 ? "error" : "incomplete"),
+      combo: { name: comboName, strategy: comboStrategy },
+      correlation: forensic,
+      attempts: [record],
+    }).catch(() => {});
+  };
 
   for (let i = 0; i < rotatedModels.length; i++) {
     const modelStr = rotatedModels[i];
     log.info("COMBO", `Trying model ${i + 1}/${rotatedModels.length}: ${modelStr}`);
 
     try {
-      const result = await handleSingleModel(body, modelStr, { role: "worker" });
+      const result = await handleSingleModel(body, modelStr, { role: "worker", candidateIndex: i, candidateOrder: [...rotatedModels] });
+      const forensic = result?.correlation;
+      const attempt = result?.canonicalAttempt;
       // Wave 1C: ChatResult.success was the authoritative application-success signal.
       // Commit F: migrate to candidateServed — finalized canonicalAttempt.logicalSuccess
       // for buffered attempts, admission (committed 2xx stream) for the outer streaming
       // handoff (chat.js returns this Response directly to the client). Transport data
       // (status/headers/body) stays on result.response.
       if (candidateServed(result)) {
+        persistAttempt({ forensic, result, attempt, fallbackDecision: "served" });
         log.info("COMBO", `Model ${modelStr} succeeded`);
         // Combo observability: notify the strategy wrapper which member actually
         // served the request (used by smart-routing telemetry).
@@ -473,7 +509,6 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       // canonical policy exists (pre-provider validation / older internal paths).
       let shouldFallback;
       let cooldownMs = 0;
-      const attempt = result.canonicalAttempt;
       const finalizedPolicy = (attempt && attempt.completionState !== "unknown") ? attempt.policy : null;
       if (finalizedPolicy) {
         shouldFallback = finalizedPolicy.stopProgression === true
@@ -494,6 +529,7 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       }
 
       if (!shouldFallback) {
+        persistAttempt({ forensic, result, attempt, fallbackDecision: "stopped" });
         log.warn("COMBO", `Model ${modelStr} failed (no fallback)`, { status });
         return result.response;
       }
@@ -508,14 +544,32 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       }
 
       // Fallback to next model
+      persistAttempt({ forensic, result, attempt, fallbackDecision: "fallback" });
       lastError = errorText || String(status);
       if (!lastStatus) lastStatus = status;
       log.warn("COMBO", `Model ${modelStr} failed, trying next`, { status });
     } catch (error) {
-      // Catch unexpected exceptions to ensure fallback continues
+      // Catch unexpected exceptions to ensure fallback continues. The provider
+      // attempt may have thrown before returning a ChatResult, so retain the
+      // attempt identity attached by the dispatch closure without persisting
+      // exception text or request content.
       lastError = error.message || String(error);
       if (!lastStatus) lastStatus = 500;
       log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError });
+      persistAttempt({
+        forensic: error?.forensic,
+        result: { status: 500 },
+        attempt: {
+          classification: "transport_failure",
+          reason: "execution_exception",
+          outcome: "failure",
+          logicalSuccess: false,
+          completionState: "failure",
+          completionType: "execution_exception",
+          errorSeen: true,
+        },
+        fallbackDecision: i < rotatedModels.length - 1 ? "fallback" : "stopped",
+      });
     }
   }
 

--- a/open-sse/utils/forcedSseAttempt.js
+++ b/open-sse/utils/forcedSseAttempt.js
@@ -111,6 +111,7 @@ export function createCanonicalAttemptFromForcedSse({
   const classification = classifyCanonicalAttempt({
     completionState, transportOk, abortSeen: !!abortSeen, errorSeen,
     completionType, usableOutput, logicalSuccess, responseStatus: status ?? null,
+    hasUsage: ev.hasUsage, usagePresent: ev.hasUsage,
   });
 
   return {
@@ -137,6 +138,7 @@ export function createCanonicalAttemptFromForcedSse({
     policy: decideAttemptPolicy({
       source: "provider", completionState, transportOk, abortSeen: !!abortSeen, errorSeen,
       completionType, usableOutput, logicalSuccess,
+      hasUsage: ev.hasUsage, usagePresent: ev.hasUsage,
       ...classification,
     }),
   };

--- a/open-sse/utils/forensicIds.js
+++ b/open-sse/utils/forensicIds.js
@@ -1,0 +1,5 @@
+export function createForensicId(prefix = "id") {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return `${prefix}_${uuid}`;
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/open-sse/utils/nonStreamingAttempt.js
+++ b/open-sse/utils/nonStreamingAttempt.js
@@ -152,6 +152,7 @@ export function createCanonicalAttemptFromNonStreaming({ status, parsed, usage =
   const classification = classifyCanonicalAttempt({
     completionState, transportOk, abortSeen: !!abortSeen, errorSeen,
     completionType, usableOutput, logicalSuccess, responseStatus: status ?? null,
+    hasUsage: ev.hasUsage, usagePresent: ev.hasUsage,
   });
 
   const result = {
@@ -180,6 +181,7 @@ export function createCanonicalAttemptFromNonStreaming({ status, parsed, usage =
     policy: decideAttemptPolicy({
       source: "provider", completionState, transportOk, abortSeen: !!abortSeen, errorSeen,
       completionType, usableOutput, logicalSuccess,
+      hasUsage: ev.hasUsage, usagePresent: ev.hasUsage,
       ...classification,
     }),
   };

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -82,6 +82,7 @@ export function createSSEStream(options = {}) {
   const enqueueTracked = (controller, data) => {
     controller.enqueue(data);
     sseEmittedCount++;
+    observed.emitted = sseEmittedCount;
   };
 
   // Track Responses API event framing for same-format passthrough (codex)
@@ -106,17 +107,20 @@ export function createSSEStream(options = {}) {
 
       for (const line of lines) {
         const trimmed = line.trim();
-      if (isDebugEnabled && trimmed) {
-        sseLineCount++;
-        if (trimmed.startsWith("event:")) {
-          eventLines++;
-          const evt = trimmed.slice(6).trim();
-          eventTypeCounts[evt] = (eventTypeCounts[evt] || 0) + 1;
+        if (trimmed) {
+          sseLineCount++;
+          observed.recvLines = sseLineCount;
+          if (trimmed.startsWith("event:")) {
+            eventLines++;
+            observed.eventLines = eventLines;
+            const evt = trimmed.slice(6).trim();
+            eventTypeCounts[evt] = (eventTypeCounts[evt] || 0) + 1;
+          }
+          if (trimmed.startsWith("data:")) {
+            dataLines++;
+            observed.dataLines = dataLines;
+          }
         }
-        if (trimmed.startsWith("data:")) {
-          dataLines++;
-        }
-      }
 
         // Capture Responses API event name to preserve framing in same-format passthrough
         if (mode === STREAM_MODE.TRANSLATE && targetFormat === FORMATS.OPENAI_RESPONSES && trimmed.startsWith("event:")) {

--- a/open-sse/utils/streamState.js
+++ b/open-sse/utils/streamState.js
@@ -50,6 +50,10 @@ export function createStreamState() {
     eofSeen: false,
     errorSeen: false,
     abortSeen: false,
+    recvLines: null,
+    dataLines: null,
+    eventLines: null,
+    emitted: null,
   };
 }
 

--- a/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
+++ b/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
@@ -419,6 +419,57 @@ export default function RequestDetailsTab() {
             </div>
             
             <div className="space-y-4">
+              {(selectedDetail.correlation || selectedDetail.transport || selectedDetail.canonicalAttempt || selectedDetail.streamObservability || (Array.isArray(selectedDetail.attempts) && selectedDetail.attempts.length > 0)) && (
+                <div className="space-y-4">
+                  {selectedDetail.correlation && (
+                    <CollapsibleSection title="Correlation" icon="hub">
+                      <pre className="max-h-[260px] max-w-full overflow-auto rounded-lg border border-black/5 bg-surface-2 p-3 font-mono text-xs text-text-main dark:border-white/5 dark:bg-white/0 sm:p-4">
+                        {JSON.stringify(selectedDetail.correlation, null, 2)}
+                      </pre>
+                    </CollapsibleSection>
+                  )}
+                  {selectedDetail.transport && (
+                    <CollapsibleSection title="Transport" icon="swap_horiz">
+                      <pre className="max-h-[220px] max-w-full overflow-auto rounded-lg border border-black/5 bg-surface-2 p-3 font-mono text-xs text-text-main dark:border-white/5 dark:bg-white/0 sm:p-4">
+                        {JSON.stringify(selectedDetail.transport, null, 2)}
+                      </pre>
+                    </CollapsibleSection>
+                  )}
+                  {selectedDetail.canonicalAttempt && (
+                    <CollapsibleSection title="Canonical Attempt" icon="fact_check">
+                      <pre className="max-h-[300px] max-w-full overflow-auto rounded-lg border border-black/5 bg-surface-2 p-3 font-mono text-xs text-text-main dark:border-white/5 dark:bg-white/0 sm:p-4">
+                        {JSON.stringify(selectedDetail.canonicalAttempt, null, 2)}
+                      </pre>
+                    </CollapsibleSection>
+                  )}
+                  {selectedDetail.streamObservability && (
+                    <CollapsibleSection title="Stream Observability" icon="stream">
+                      <pre className="max-h-[300px] max-w-full overflow-auto rounded-lg border border-black/5 bg-surface-2 p-3 font-mono text-xs text-text-main dark:border-white/5 dark:bg-white/0 sm:p-4">
+                        {JSON.stringify(selectedDetail.streamObservability, null, 2)}
+                      </pre>
+                    </CollapsibleSection>
+                  )}
+                  {Array.isArray(selectedDetail.attempts) && selectedDetail.attempts.length > 0 && (
+                    <CollapsibleSection title={`Fallback Attempts (${selectedDetail.attempts.length})`} icon="route">
+                      <div className="space-y-3">
+                        {selectedDetail.attempts.map((attempt, index) => (
+                          <div key={attempt.attemptId || index} className="rounded-lg border border-border-subtle bg-surface-2 p-3 text-xs">
+                            <div className="mb-2 flex flex-wrap gap-x-4 gap-y-1 font-medium text-text-main">
+                              <span>#{attempt.candidateIndex ?? index}</span>
+                              <span>{attempt.candidateModel || "unknown model"}</span>
+                              <span>{attempt.fallbackDecision || "—"}</span>
+                            </div>
+                            <pre className="max-h-[240px] overflow-auto font-mono text-text-muted">
+                              {JSON.stringify(attempt, null, 2)}
+                            </pre>
+                          </div>
+                        ))}
+                      </div>
+                    </CollapsibleSection>
+                  )}
+                </div>
+              )}
+
               <CollapsibleSection title="1. Client Request (Input)" defaultOpen={true} icon="input">
                 <pre className="max-h-[300px] max-w-full overflow-auto rounded-lg border border-black/5 bg-surface-2 p-3 font-mono text-xs text-text-main dark:border-white/5 dark:bg-white/0 sm:p-4">
                   {JSON.stringify(selectedDetail.request, null, 2)}

--- a/src/lib/db/repos/requestDetailsRepo.js
+++ b/src/lib/db/repos/requestDetailsRepo.js
@@ -6,6 +6,7 @@ const DEFAULT_MAX_RECORDS = 200;
 const DEFAULT_BATCH_SIZE = 20;
 const DEFAULT_FLUSH_INTERVAL_MS = 5000;
 const DEFAULT_MAX_JSON_SIZE = 5 * 1024;
+const DEFAULT_MAX_ATTEMPTS = 32;
 const CONFIG_CACHE_TTL_MS = 5000;
 
 let cachedConfig = null;
@@ -31,6 +32,7 @@ async function getObservabilityConfig() {
       batchSize: settings.observabilityBatchSize || parseInt(process.env.OBSERVABILITY_BATCH_SIZE || String(DEFAULT_BATCH_SIZE), 10),
       flushIntervalMs: settings.observabilityFlushIntervalMs || parseInt(process.env.OBSERVABILITY_FLUSH_INTERVAL_MS || String(DEFAULT_FLUSH_INTERVAL_MS), 10),
       maxJsonSize: (settings.observabilityMaxJsonSize || parseInt(process.env.OBSERVABILITY_MAX_JSON_SIZE || "5", 10)) * 1024,
+      maxAttempts: settings.observabilityMaxAttempts || parseInt(process.env.OBSERVABILITY_MAX_ATTEMPTS || String(DEFAULT_MAX_ATTEMPTS), 10),
     };
   } catch {
     cachedConfig = {
@@ -39,6 +41,7 @@ async function getObservabilityConfig() {
       batchSize: DEFAULT_BATCH_SIZE,
       flushIntervalMs: DEFAULT_FLUSH_INTERVAL_MS,
       maxJsonSize: DEFAULT_MAX_JSON_SIZE,
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
     };
   }
   cachedConfigTs = Date.now();
@@ -100,6 +103,50 @@ function truncateField(obj, maxSize) {
   return obj || {};
 }
 
+function safeStructuredField(value, maxSize) {
+  if (value == null) return null;
+  return truncateField(redactSecretsDeep(value), maxSize);
+}
+
+function safeAttemptsField(attempts, maxSize) {
+  if (!Array.isArray(attempts) || attempts.length === 0) return null;
+  const redacted = attempts.map((attempt) => redactSecretsDeep(attempt));
+  if (JSON.stringify(redacted).length <= maxSize) return redacted;
+
+  const kept = [];
+  for (let i = redacted.length - 1; i >= 0; i--) {
+    const candidate = [redacted[i], ...kept];
+    if (JSON.stringify(candidate).length > maxSize) break;
+    kept.unshift(redacted[i]);
+  }
+  return kept.length > 0 ? kept : [{
+    attemptId: redacted[redacted.length - 1]?.attemptId || null,
+    classification: redacted[redacted.length - 1]?.classification || null,
+    reason: redacted[redacted.length - 1]?.reason || null,
+    _truncated: true,
+  }];
+}
+
+function mergeAttempts(existing, incoming, maxAttempts = DEFAULT_MAX_ATTEMPTS) {
+  const prior = Array.isArray(existing) ? existing : [];
+  const next = Array.isArray(incoming) ? incoming : [];
+  const merged = [];
+  const positions = new Map();
+  for (const attempt of [...prior, ...next]) {
+    if (!attempt || typeof attempt !== "object") continue;
+    const id = typeof attempt.attemptId === "string" && attempt.attemptId
+      ? attempt.attemptId
+      : null;
+    if (id && positions.has(id)) {
+      merged[positions.get(id)] = attempt;
+      continue;
+    }
+    if (id) positions.set(id, merged.length);
+    merged.push(attempt);
+  }
+  return merged.slice(-Math.max(1, maxAttempts));
+}
+
 async function flushToDatabase() {
   if (isFlushing) return;
   if (writeBuffer.length === 0) return;
@@ -117,30 +164,45 @@ async function flushToDatabase() {
           if (!item.timestamp) item.timestamp = new Date().toISOString();
           if (item.request?.headers) item.request.headers = sanitizeHeaders(item.request.headers);
 
+          const existingRow = db.get(`SELECT status, data FROM requestDetails WHERE id = ?`, [item.id]);
+          const existingData = existingRow?.data ? parseJson(existingRow.data, {}) : {};
+          const attempts = mergeAttempts(existingData.attempts, item.attempts, config.maxAttempts);
           const record = {
             id: item.id,
-            provider: item.provider || null,
-            model: item.model || null,
-            connectionId: item.connectionId || null,
+            provider: item.provider || existingData.provider || null,
+            model: item.model || existingData.model || null,
+            connectionId: item.connectionId || existingData.connectionId || null,
             timestamp: item.timestamp,
-            status: item.status || null,
-            latency: item.latency || {},
-            tokens: item.tokens || {},
-            // Combo observability: which combo/strategy/role/trafficClass
-            // produced this call (null for plain single-model requests).
-            combo: item.combo || null,
-            request: truncateField(redactSecretsDeep(item.request), config.maxJsonSize),
-            providerRequest: truncateField(redactSecretsDeep(item.providerRequest), config.maxJsonSize),
-            providerResponse: truncateField(redactSecretsDeep(item.providerResponse), config.maxJsonSize),
-            response: truncateField(redactSecretsDeep(item.response), config.maxJsonSize),
+            status: item.status || existingRow?.status || null,
+            latency: item.latency || existingData.latency || {},
+            tokens: item.tokens || existingData.tokens || {},
+            combo: safeStructuredField(item.combo ?? existingData.combo, config.maxJsonSize),
+            request: item.request !== undefined
+              ? truncateField(redactSecretsDeep(item.request), config.maxJsonSize)
+              : (existingData.request || {}),
+            providerRequest: item.providerRequest !== undefined
+              ? truncateField(redactSecretsDeep(item.providerRequest), config.maxJsonSize)
+              : (existingData.providerRequest || null),
+            providerResponse: item.providerResponse !== undefined
+              ? truncateField(redactSecretsDeep(item.providerResponse), config.maxJsonSize)
+              : (existingData.providerResponse || null),
+            response: item.response !== undefined
+              ? truncateField(redactSecretsDeep(item.response), config.maxJsonSize)
+              : (existingData.response || {}),
+            ...(item.endpoint !== undefined || existingData.endpoint !== undefined ? { endpoint: item.endpoint ?? existingData.endpoint ?? null } : {}),
+            ...(item.transport !== undefined || existingData.transport !== undefined ? { transport: safeStructuredField(item.transport ?? existingData.transport, config.maxJsonSize) } : {}),
+            ...(item.correlation !== undefined || existingData.correlation !== undefined ? { correlation: safeStructuredField(item.correlation ?? existingData.correlation, config.maxJsonSize) } : {}),
+            ...(item.canonicalAttempt !== undefined || existingData.canonicalAttempt !== undefined ? { canonicalAttempt: safeStructuredField(item.canonicalAttempt ?? existingData.canonicalAttempt, config.maxJsonSize) } : {}),
+            ...(item.streamObservability !== undefined || existingData.streamObservability !== undefined ? { streamObservability: safeStructuredField(item.streamObservability ?? existingData.streamObservability, config.maxJsonSize) } : {}),
+            ...(attempts.length > 0 ? { attempts: safeAttemptsField(attempts, config.maxJsonSize) } : {}),
           };
 
-          // Lifecycle guard: the FIRST terminal status wins. A row that has
-          // reached a terminal state can only be refreshed by the SAME status
-          // (content/usage upgrade) — never silently reverted to a different
-          // terminal outcome (e.g. success → cancelled after a racing abort).
-          const existing = db.get(`SELECT status FROM requestDetails WHERE id = ?`, [record.id]);
-          if (shouldSkipRequestDetailOverwrite(existing?.status, record.status)) {
+          // Lifecycle guard: the FIRST terminal status wins. Historical attempt
+          // evidence is merged above even when the main row status is protected.
+          if (shouldSkipRequestDetailOverwrite(existingRow?.status, record.status)) {
+            if (attempts.length > 0 && JSON.stringify(attempts) !== JSON.stringify(existingData.attempts || [])) {
+              db.run(`UPDATE requestDetails SET data = ? WHERE id = ?`, [stringifyJson({ ...existingData, attempts: safeAttemptsField(attempts, config.maxJsonSize) }), record.id]);
+            }
             continue;
           }
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -33,6 +33,7 @@ import { decideAttemptPolicy } from "open-sse/utils/canonicalPolicy.js";
 import { buildComboExecutionGraph, authorizeComboExecution, resolveComboStrategyConfig } from "../services/comboExecutionPolicy.js";
 import { acquireComboAdmission, wrapResponseWithAdmission } from "../services/comboAdmission.js";
 import { createComboBudget } from "open-sse/services/comboBudget.js";
+import { createForensicId } from "open-sse/utils/forensicIds.js";
 
 /**
  * Execute a health action from a canonical policy result.
@@ -321,6 +322,8 @@ function resolveThinkingForComboRole(comboThinking, role) {
 
 async function dispatchResolvedCombo({ body, graph, clientRawRequest, request, apiKey, settings, signal, budget, principalId, keyObj }) {
   const { comboName, config, members } = graph;
+  const requestId = createForensicId("req");
+  let executionIndex = 0;
   const strategy = config.fallbackStrategy;
   const comboThinking = config?.thinking;
 
@@ -339,21 +342,38 @@ async function dispatchResolvedCombo({ body, graph, clientRawRequest, request, a
       const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
       cleanRawReq = { ...clientRawRequest, body: cleanBody };
     }
-    const result = await handleSingleModelChat(b, m, cleanRawReq, request, apiKey, {
-      skipBreaker: opts.isPanel,
-      signal: opts.signal,
-      trafficClass: opts.trafficClass || (opts.isPanel ? "panel" : "user"),
-      thinking: effectiveThinking,
-      keyObj,
-      // Combo observability: record which combo/strategy/role produced this
-      // provider call so requestDetails is audit-able against template intent.
-      comboContext: {
-        name: comboName,
-        strategy,
-        role: opts.role || (opts.isPanel ? "panel" : null),
+    const forensicMeta = {
+      requestId,
+      executionIndex: executionIndex++,
+      comboId: graph.comboId,
+      comboName,
+      candidateIndex: Number.isInteger(opts.candidateIndex) ? opts.candidateIndex : null,
+      candidateOrder: Array.isArray(opts.candidateOrder) ? [...opts.candidateOrder] : null,
+      candidateModel: m,
+      physicalProviderAlias: typeof m === "string" && m.includes("/") ? m.slice(0, m.indexOf("/")) : null,
+    };
+    let result;
+    try {
+      result = await handleSingleModelChat(b, m, cleanRawReq, request, apiKey, {
+        skipBreaker: opts.isPanel,
+        forensicMeta,
+        signal: opts.signal,
         trafficClass: opts.trafficClass || (opts.isPanel ? "panel" : "user"),
-      },
-    });
+        thinking: effectiveThinking,
+        keyObj,
+        // Combo observability: record which combo/strategy/role/trafficClass produced
+        // this provider call so requestDetails is audit-able against template intent.
+        comboContext: {
+          name: comboName,
+          strategy,
+          role: opts.role || (opts.isPanel ? "panel" : null),
+          trafficClass: opts.trafficClass || (opts.isPanel ? "panel" : "user"),
+        },
+      });
+    } catch (error) {
+      if (error && typeof error === "object") error.forensic = forensicMeta;
+      throw error;
+    }
     // Wave 1C: strategies consume ChatResult.success as the authoritative
     // application-success signal; transport data stays on result.response.
     return result;
@@ -620,7 +640,16 @@ export async function handleSingleModelChat(body, modelStr, clientRawRequest = n
       opencodeIdentity,
       // Combo observability: which combo/strategy/role/trafficClass produced
       // this provider call (undefined for plain single-model requests).
-      comboContext: opts.comboContext,
+      comboContext: {
+        name: comboName,
+        strategy,
+        role: opts.role || (opts.isPanel ? "panel" : null),
+        trafficClass: opts.trafficClass || (opts.isPanel ? "panel" : "user"),
+      },
+      forensicMeta: {
+        ...(opts.forensicMeta || {}),
+        attemptId: createForensicId("attempt"),
+      },
       onCredentialsRefreshed: async (newCreds) => {
         await updateProviderCredentials(credentials.connectionId, {
           ...newCreds,

--- a/tests/unit/empty-model-response-forensics.test.js
+++ b/tests/unit/empty-model-response-forensics.test.js
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { comboSaveRequestDetail } = vi.hoisted(() => ({
+  comboSaveRequestDetail: vi.fn(async () => {}),
+}));
+
+// Forensic characterization only. These tests pin the observed failure boundary
+// without changing retry, cooldown, fallback, or combo behavior.
+vi.mock("../../open-sse/services/providerCapabilities.js", () => ({
+  validateComboRoles: () => [],
+}));
+
+vi.mock("@/lib/usageDb.js", () => ({
+  saveRequestDetail: comboSaveRequestDetail,
+}));
+
+const { handleComboChat } = await import("../../open-sse/services/combo.js");
+const { createCanonicalAttemptFromNonStreaming } = await import("../../open-sse/utils/nonStreamingAttempt.js");
+const { mapCanonicalAttemptToRequestStatus } = await import("../../open-sse/utils/requestDetailStatus.js");
+
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+function emptyAttempt({ usage = null } = {}) {
+  return createCanonicalAttemptFromNonStreaming({
+    status: 200,
+    parsed: usage ? { choices: [], usage } : { choices: [] },
+    usage,
+    malformed: false,
+  });
+}
+
+function emptyResult({ usage = null } = {}) {
+  const body = usage ? { id: "empty-usage", choices: [], usage } : { id: "empty", choices: [] };
+  return {
+    success: true,
+    status: 200,
+    response: new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    canonicalAttempt: emptyAttempt({ usage }),
+  };
+}
+
+function successResult(model = "provider-b/model-b") {
+  const body = {
+    id: "success",
+    model,
+    choices: [{ message: { role: "assistant", content: "answer" }, finish_reason: "stop" }],
+  };
+  return {
+    success: true,
+    status: 200,
+    response: new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    canonicalAttempt: createCanonicalAttemptFromNonStreaming({
+      status: 200,
+      parsed: body,
+      usage: null,
+      malformed: false,
+    }),
+  };
+}
+
+describe("empty_model_response forensic characterization", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("classifies HTTP 200 empty choices as empty_output, not logical success", () => {
+    const attempt = emptyAttempt();
+
+    expect(attempt.transportOk).toBe(true);
+    expect(attempt.hasText).toBe(false);
+    expect(attempt.hasReasoning).toBe(false);
+    expect(attempt.hasToolCall).toBe(false);
+    expect(attempt.hasStructuredOutput).toBe(false);
+    expect(attempt.hasUsage).toBe(false);
+    expect(attempt.completionState).toBe("incomplete");
+    expect(attempt.logicalSuccess).toBe(false);
+    expect(attempt.classification).toBe("empty_output");
+    expect(attempt.reason).toBe("empty_response");
+    expect(attempt.policy.fallbackEligible).toBe(true);
+    expect(attempt.policy.retryable).toBe(true);
+    expect(mapCanonicalAttemptToRequestStatus(attempt)).toBe("empty_output");
+  });
+
+  it("records usage evidence as usage_only without treating it as usable output", () => {
+    const attempt = emptyAttempt({
+      usage: { prompt_tokens: 8, completion_tokens: 0 },
+    });
+
+    expect(attempt.transportOk).toBe(true);
+    expect(attempt.hasUsage).toBe(true);
+    expect(attempt.usableOutput).toBe(false);
+    expect(attempt.logicalSuccess).toBe(false);
+    expect(attempt.classification).toBe("empty_output");
+    expect(attempt.reason).toBe("usage_only");
+  });
+
+  it("retains both executed candidates when empty output falls back to success", async () => {
+    const saveRequestDetail = comboSaveRequestDetail;
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce({
+        ...emptyResult(),
+        correlation: {
+          requestId: "req_acceptance",
+          attemptId: "attempt_empty",
+          physicalProviderId: "provider-a",
+          physicalProviderAlias: "provider-a",
+          physicalModel: "model-a",
+          executor: { implementation: "DefaultExecutor", dispatch: "default_executor" },
+        },
+      })
+      .mockResolvedValueOnce({
+        ...successResult(),
+        correlation: {
+          requestId: "req_acceptance",
+          attemptId: "attempt_success",
+          physicalProviderId: "provider-b",
+          physicalProviderAlias: "provider-b",
+          physicalModel: "model-b",
+          executor: { implementation: "DefaultExecutor", dispatch: "default_executor" },
+        },
+      });
+
+    const response = await handleComboChat({
+      body: { model: "combo", stream: false },
+      models: ["provider-a/model-a", "provider-b/model-b"],
+      handleSingleModel,
+      log,
+      comboName: "combo",
+      comboStrategy: "fallback",
+      autoSwitch: false,
+    });
+
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(saveRequestDetail).toHaveBeenCalledTimes(2));
+    const calls = saveRequestDetail.mock.calls.map(([detail]) => detail);
+    expect(calls.flatMap((detail) => detail.attempts || []).map((attempt) => attempt.attemptId)).toEqual([
+      "attempt_empty",
+      "attempt_success",
+    ]);
+    expect(calls[0].attempts[0].reason).toBe("empty_response");
+    expect(calls[1].attempts[0].fallbackDecision).toBe("served");
+  });
+
+  it("persists every failed candidate in an all-failed combo", async () => {
+    const saveRequestDetail = comboSaveRequestDetail;
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce({
+        ...emptyResult(),
+        correlation: { requestId: "req_failed", attemptId: "attempt_a", physicalProviderId: "provider-a", physicalModel: "model-a" },
+      })
+      .mockResolvedValueOnce({
+        ...emptyResult(),
+        correlation: { requestId: "req_failed", attemptId: "attempt_b", physicalProviderId: "provider-b", physicalModel: "model-b" },
+      });
+
+    const response = await handleComboChat({
+      body: { model: "combo", stream: false },
+      models: ["provider-a/model-a", "provider-b/model-b"],
+      handleSingleModel,
+      log,
+      comboName: "combo",
+      comboStrategy: "fallback",
+      autoSwitch: false,
+    });
+
+    expect(response.status).toBe(503);
+    await vi.waitFor(() => expect(saveRequestDetail).toHaveBeenCalledTimes(2));
+    const attempts = saveRequestDetail.mock.calls.flatMap(([detail]) => detail.attempts || []);
+    expect(attempts.map((attempt) => attempt.attemptId)).toEqual(["attempt_a", "attempt_b"]);
+    expect(attempts.every((attempt) => attempt.fallbackDecision === "fallback" || attempt.fallbackDecision === "stopped")).toBe(true);
+  });
+
+  it("progresses past an empty canonical candidate, then exposes the ambiguous all-failed envelope", async () => {
+    const calls = [];
+    const handleSingleModel = vi.fn(async (_body, model) => {
+      calls.push(model);
+      return emptyResult();
+    });
+
+    const response = await handleComboChat({
+      body: { model: "gpt-5.6-sol", stream: false },
+      models: ["provider-a/model-a", "provider-b/model-b"],
+      handleSingleModel,
+      log,
+      comboName: "gpt-5.6-sol",
+      comboStrategy: "fallback",
+      autoSwitch: false,
+    });
+    const body = await response.json();
+
+    expect(calls).toEqual(["provider-a/model-a", "provider-b/model-b"]);
+    expect(response.status).toBe(503);
+    // Current behavior: a 2xx empty result has no error text, so exhaustion
+    // falls back to String(status). This is the observed ambiguity, not a fix.
+    expect(body.error.message).toBe("200");
+    expect(body.error.code).toBe("all_models_failed");
+  });
+});
+
+// The request-details repository currently whitelists legacy fields before
+// serializing. Keep this as a separate module-level characterization so a future
+// forensic persistence change can prove exactly when evidence becomes durable.
+const { getAdapterMock, getSettingsMock } = vi.hoisted(() => ({
+  getAdapterMock: vi.fn(),
+  getSettingsMock: vi.fn(),
+}));
+
+vi.mock("../../src/lib/db/driver.js", () => ({ getAdapter: getAdapterMock }));
+vi.mock("../../src/lib/db/repos/settingsRepo.js", () => ({ getSettings: getSettingsMock }));
+
+const { saveRequestDetail } = await import("../../src/lib/db/repos/requestDetailsRepo.js");
+
+describe("request-detail forensic evidence characterization", () => {
+  let inserted;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    inserted = null;
+    getSettingsMock.mockResolvedValue({
+      enableObservability: true,
+      observabilityBatchSize: 1,
+      observabilityFlushIntervalMs: 60_000,
+      observabilityMaxRecords: 200,
+      observabilityMaxJsonSize: 64,
+    });
+    getAdapterMock.mockResolvedValue({
+      transaction(callback) { callback(); },
+      get(sql) {
+        if (sql.startsWith("SELECT COUNT")) return { c: 0 };
+        return undefined;
+      },
+      run(sql, params) {
+        if (sql.startsWith("INSERT INTO requestDetails")) inserted = JSON.parse(params[6]);
+      },
+    });
+  });
+
+  it("persists canonical attempt and stream observability through SQLite serialization", async () => {
+    await saveRequestDetail({
+      id: "forensic-detail-1",
+      provider: "codex",
+      model: "gpt-5.6-luna",
+      status: "empty_output",
+      canonicalAttempt: {
+        classification: "empty_output",
+        reason: "empty_response",
+        transportOk: true,
+        logicalSuccess: false,
+      },
+      streamObservability: {
+        eofSeen: true,
+        terminalSeen: false,
+        hasText: false,
+      },
+    });
+
+    await vi.waitFor(() => expect(inserted).not.toBeNull());
+    expect(inserted.status).toBe("empty_output");
+    expect(inserted.canonicalAttempt).toEqual({
+      classification: "empty_output",
+      reason: "empty_response",
+      transportOk: true,
+      logicalSuccess: false,
+    });
+    expect(inserted.streamObservability).toEqual({
+      eofSeen: true,
+      terminalSeen: false,
+      hasText: false,
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Request details now include expandable correlation, transport, response-attempt, streaming, and fallback information.
  - Provider attempts and fallback decisions are recorded for improved visibility into completed and failed requests.
  - Streaming request details now show event, data, line, and emitted-event counts.

- **Bug Fixes**
  - Improved preservation and deduplication of request history, including updates with newly available attempt information.
  - Empty or usage-only responses are classified and recorded more consistently.

- **Tests**
  - Added coverage for empty responses, fallback behavior, attempt persistence, and streaming observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->